### PR TITLE
[packaging] Use transfiletriggerin to restart ofono when a plugin is installed. JB#55233

### DIFF
--- a/rpm/ofono.spec
+++ b/rpm/ofono.spec
@@ -130,6 +130,9 @@ systemctl daemon-reload ||:
 %postun
 systemctl daemon-reload ||:
 
+%transfiletriggerin -- %{_libdir}/ofono/plugins
+systemctl try-restart ofono.service ||:
+
 %files
 %defattr(-,root,root,-)
 %license COPYING


### PR DESCRIPTION
Unfortunately this will also cause ofono to be restarted when it itself is updated so i am not sure if this is a good idea.