### PR TITLE
[Needs Testing] Bump Ofono to v1.24

### DIFF
--- a/ofono/AUTHORS
+++ b/ofono/AUTHORS
@@ -130,3 +130,4 @@ Joey Hewitt <joey@joeyhewitt.com>
 Richard Röjfors <richard.rojfors@gmail.com>
 Philippe De Swert <philippe.deswert@nomovok.com>
 Gabriel Lucas <gabriel.lucas@smile.fr>
+Mariem Cherif <mariem.cherif@ardia.com.tn>

--- a/ofono/AUTHORS
+++ b/ofono/AUTHORS
@@ -134,3 +134,4 @@ Mariem Cherif <mariem.cherif@ardia.com.tn>
 Bassem Boubaker <bassem.boubaker@actia.fr>
 Bob Ham <bob.ham@puri.sm>
 Varun Gargi <varun.gargi@intel.com>
+Florent Beillonnet <florent.beillonnet@gmail.com>

--- a/ofono/AUTHORS
+++ b/ofono/AUTHORS
@@ -132,3 +132,4 @@ Philippe De Swert <philippe.deswert@nomovok.com>
 Gabriel Lucas <gabriel.lucas@smile.fr>
 Mariem Cherif <mariem.cherif@ardia.com.tn>
 Bassem Boubaker <bassem.boubaker@actia.fr>
+Bob Ham <bob.ham@puri.sm>

--- a/ofono/AUTHORS
+++ b/ofono/AUTHORS
@@ -133,3 +133,4 @@ Gabriel Lucas <gabriel.lucas@smile.fr>
 Mariem Cherif <mariem.cherif@ardia.com.tn>
 Bassem Boubaker <bassem.boubaker@actia.fr>
 Bob Ham <bob.ham@puri.sm>
+Varun Gargi <varun.gargi@intel.com>

--- a/ofono/AUTHORS
+++ b/ofono/AUTHORS
@@ -131,3 +131,4 @@ Richard Röjfors <richard.rojfors@gmail.com>
 Philippe De Swert <philippe.deswert@nomovok.com>
 Gabriel Lucas <gabriel.lucas@smile.fr>
 Mariem Cherif <mariem.cherif@ardia.com.tn>
+Bassem Boubaker <bassem.boubaker@actia.fr>

--- a/ofono/ChangeLog
+++ b/ofono/ChangeLog
@@ -1,3 +1,16 @@
+ver 1.24:
+	Fix issue with property changed signals and CDMA networks.
+	Fix issue with handling SIM filesystem and SIM removal.
+	Fix issue with handling PIN state and incorrect codes.
+	Fix issue with handling of parsing AID type.
+	Fix issue with SIM detection and QMI devices.
+	Fix issue with PIN handling and QMI devices.
+	Fix issue with USSD handling and QMI devices.
+	Fix issue with handling USSD TERMINATED response.
+	Fix issue with handling USSD reset and STK REFRESH.
+	Add support for detecting Gemalto ALS3 modems.
+	Add support for SIMCom based SIM7100E modems.
+
 ver 1.23:
 	Fix issue with handling SIM AID sessions.
 	Add support for QMI LTE bearer handling.

--- a/ofono/Makefile.am
+++ b/ofono/Makefile.am
@@ -573,6 +573,12 @@ builtin_sources += plugins/samsung.c
 builtin_modules += sim900
 builtin_sources += plugins/sim900.c
 
+builtin_modules += sim7100
+builtin_sources += plugins/sim7100.c
+
+builtin_modules += connman
+builtin_sources += plugins/connman.c
+
 builtin_modules += telit
 builtin_sources += plugins/telit.c
 

--- a/ofono/configure.ac
+++ b/ofono/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.60)
-AC_INIT(ofono, 1.23)
+AC_INIT(ofono, 1.24)
 
 AM_INIT_AUTOMAKE([foreign subdir-objects color-tests])
 AC_CONFIG_HEADERS(config.h)

--- a/ofono/drivers/atmodem/cbs.c
+++ b/ofono/drivers/atmodem/cbs.c
@@ -48,6 +48,51 @@ struct cbs_data {
 	unsigned int vendor;
 };
 
+static void at_xmm_etw_sec_notify(GAtResult *result, gpointer user_data)
+{
+	struct ofono_cbs *cbs = user_data;
+	const char *hexpdu;
+	int pdulen;
+	GAtResultIter iter;
+	unsigned char pdu[88];
+	long hexpdulen;
+
+	DBG("");
+
+	g_at_result_iter_init(&iter, result);
+
+	if (!g_at_result_iter_next(&iter, "+XETWSECWARN:"))
+		return;
+
+	if (!g_at_result_iter_next_number(&iter, &pdulen))
+		return;
+
+	if (pdulen != 88) {
+		ofono_error("Got a CBM message with invalid PDU size!");
+		return;
+	}
+
+	hexpdu = g_at_result_pdu(result);
+	if (hexpdu == NULL) {
+		ofono_error("Got a CBM, but no PDU.  Are we in text mode?");
+		return;
+	}
+
+	DBG("Got new Cell Broadcast via XETWSECWARN: %s, %d", hexpdu, pdulen);
+
+	if (decode_hex_own_buf(hexpdu, -1, &hexpdulen, 0, pdu) == NULL) {
+		ofono_error("Unable to hex-decode the PDU");
+		return;
+	}
+
+	if (hexpdulen != pdulen) {
+		ofono_error("hexpdu length not equal to reported pdu length");
+		return;
+	}
+
+	ofono_cbs_notify(cbs, pdu, pdulen);
+}
+
 static void at_cbm_notify(GAtResult *result, gpointer user_data)
 {
 	struct ofono_cbs *cbs = user_data;
@@ -124,6 +169,10 @@ static void at_cbs_set_topics(struct ofono_cbs *cbs, const char *topics,
 		g_at_chat_send(data->chat, "AT+CSCB=0", none_prefix,
 				NULL, NULL, NULL);
 		break;
+	case OFONO_VENDOR_XMM:
+		g_at_chat_send(data->chat, "AT+XETWNTFYSTART=2", none_prefix,
+				NULL, NULL, NULL);
+		break;
 	default:
 		break;
 	}
@@ -151,6 +200,10 @@ static void at_cbs_clear_topics(struct ofono_cbs *cbs,
 
 	DBG("");
 
+	if (data->vendor == OFONO_VENDOR_XMM)
+                g_at_chat_send(data->chat, "AT+XETWNTFYSTOP=2", none_prefix,
+                                NULL, NULL, NULL);
+
 	if (g_at_chat_send(data->chat, "AT+CSCB=0", none_prefix,
 				at_cscb_set_cb, cbd, g_free) > 0)
 		return;
@@ -174,6 +227,10 @@ static void at_cbs_register(gboolean ok, GAtResult *result, gpointer user)
 	 * appropriately for us
 	 */
 	g_at_chat_register(data->chat, "+CBM:", at_cbm_notify, TRUE, cbs, NULL);
+
+	if (data->vendor == OFONO_VENDOR_XMM)
+		g_at_chat_register(data->chat, "+XETWSECWARN:",
+					at_xmm_etw_sec_notify, TRUE, cbs, NULL);
 
 	ofono_cbs_register(cbs);
 }
@@ -222,6 +279,13 @@ static int at_cbs_probe(struct ofono_cbs *cbs, unsigned int vendor,
 	data->vendor = vendor;
 
 	ofono_cbs_set_data(cbs, data);
+
+	if (vendor == OFONO_VENDOR_XMM) {
+		g_at_chat_send(data->chat, "AT+XCMAS=1", cscb_prefix,
+				NULL, NULL, NULL);
+		g_at_chat_send(data->chat, "AT+XETWCFG=1,1,0,0; ", none_prefix,
+				NULL, NULL, NULL);
+	}
 
 	g_at_chat_send(data->chat, "AT+CSCB=?", cscb_prefix,
 			at_cscb_support_cb, cbs, NULL);

--- a/ofono/drivers/atmodem/lte.c
+++ b/ofono/drivers/atmodem/lte.c
@@ -91,7 +91,7 @@ static gboolean lte_delayed_register(gpointer user_data)
 	return FALSE;
 }
 
-static int at_lte_probe(struct ofono_lte *lte, void *data)
+static int at_lte_probe(struct ofono_lte *lte, unsigned int vendor, void *data)
 {
 	GAtChat *chat = data;
 	struct lte_driver_data *ldd;

--- a/ofono/drivers/atmodem/sim.c
+++ b/ofono/drivers/atmodem/sim.c
@@ -1359,12 +1359,12 @@ static void at_pin_send_puk(struct ofono_sim *sim, const char *puk,
 	char buf[64];
 	int ret;
 
-	cbd->user = sd;
+	cbd->user = sim;
 
 	snprintf(buf, sizeof(buf), "AT+CPIN=\"%s\",\"%s\"", puk, passwd);
 
 	ret = g_at_chat_send(sd->chat, buf, none_prefix,
-				at_pin_send_cb, cbd, NULL);
+				at_pin_send_cb, cbd, g_free);
 
 	memset(buf, 0, sizeof(buf));
 

--- a/ofono/drivers/atmodem/voicecall.c
+++ b/ofono/drivers/atmodem/voicecall.c
@@ -1120,6 +1120,7 @@ static int at_voicecall_probe(struct ofono_voicecall *vc, unsigned int vendor,
 
 	switch (vd->vendor) {
 	case OFONO_VENDOR_QUALCOMM_MSM:
+	case OFONO_VENDOR_SIMCOM:
 		g_at_chat_send(vd->chat, "AT+COLP=0", NULL, NULL, NULL, NULL);
 		break;
 	default:

--- a/ofono/drivers/qmimodem/devinfo.c
+++ b/ofono/drivers/qmimodem/devinfo.c
@@ -129,6 +129,7 @@ static void get_ids_cb(struct qmi_result *result, void *user_data)
 	str = qmi_result_get_string(result, QMI_DMS_RESULT_ESN);
 	/* Telit qmi modems return a "0" string when ESN is not available. */
 	if (!str || strcmp(str, "0") == 0) {
+		qmi_free(str);
 		str = qmi_result_get_string(result, QMI_DMS_RESULT_IMEI);
 		if (!str) {
 			CALLBACK_WITH_FAILURE(cb, NULL, cbd->data);

--- a/ofono/drivers/qmimodem/lte.c
+++ b/ofono/drivers/qmimodem/lte.c
@@ -212,7 +212,8 @@ error:
 	ofono_lte_register(lte);
 }
 
-static int qmimodem_lte_probe(struct ofono_lte *lte, void *data)
+static int qmimodem_lte_probe(struct ofono_lte *lte,
+					unsigned int vendor, void *data)
 {
 	struct qmi_device *device = data;
 	struct lte_data *ldd;

--- a/ofono/drivers/qmimodem/qmi.h
+++ b/ofono/drivers/qmimodem/qmi.h
@@ -61,13 +61,6 @@ enum qmi_device_expected_data_format {
 	QMI_DEVICE_EXPECTED_DATA_FORMAT_RAW_IP,
 };
 
-struct qmi_version {
-	uint8_t type;
-	uint16_t major;
-	uint16_t minor;
-	const char *name;
-};
-
 void qmi_free(void *ptr);
 
 typedef void (*qmi_destroy_func_t)(void *user_data);
@@ -78,8 +71,7 @@ struct qmi_device;
 typedef void (*qmi_debug_func_t)(const char *str, void *user_data);
 typedef void (*qmi_sync_func_t)(void *user_data);
 typedef void (*qmi_shutdown_func_t)(void *user_data);
-typedef void (*qmi_discover_func_t)(uint8_t count,
-			const struct qmi_version *list, void *user_data);
+typedef void (*qmi_discover_func_t)(void *user_data);
 
 struct qmi_device *qmi_device_new(int fd);
 
@@ -95,6 +87,10 @@ bool qmi_device_discover(struct qmi_device *device, qmi_discover_func_t func,
 				void *user_data, qmi_destroy_func_t destroy);
 bool qmi_device_shutdown(struct qmi_device *device, qmi_shutdown_func_t func,
 				void *user_data, qmi_destroy_func_t destroy);
+
+bool qmi_device_has_service(struct qmi_device *device, uint8_t type);
+bool qmi_device_get_service_version(struct qmi_device *device, uint8_t type,
+					uint16_t *major, uint16_t *minor);
 
 bool qmi_device_sync(struct qmi_device *device,
 		     qmi_sync_func_t func, void *user_data);

--- a/ofono/drivers/qmimodem/sim.c
+++ b/ofono/drivers/qmimodem/sim.c
@@ -557,7 +557,7 @@ static enum get_card_status_result handle_get_card_status_result(
 
 			index = GUINT16_FROM_LE(status->index_gw_pri);
 
-			if ((index & 0xff) == i && (index >> 8) == n) {
+			if ((index & 0xff) == n && (index >> 8) == i) {
 				if (get_card_status(slot, info1, info2,
 								sim_stat))
 					res = GET_CARD_STATUS_RESULT_TEMP_ERROR;

--- a/ofono/drivers/qmimodem/sim.c
+++ b/ofono/drivers/qmimodem/sim.c
@@ -612,9 +612,10 @@ static void query_passwd_state_cb(struct qmi_result *result,
 	case GET_CARD_STATUS_RESULT_OK:
 		DBG("passwd state %d", sim_stat.passwd_state);
 		data->retry_count = 0;
-		if (sim_stat.passwd_state == OFONO_SIM_PASSWORD_INVALID)
+		if (sim_stat.passwd_state == OFONO_SIM_PASSWORD_INVALID) {
 			CALLBACK_WITH_FAILURE(cb, -1, cbd->data);
-		else
+			ofono_sim_inserted_notify(sim, FALSE);
+		} else
 			CALLBACK_WITH_SUCCESS(cb, sim_stat.passwd_state,
 								cbd->data);
 		break;
@@ -626,6 +627,7 @@ static void query_passwd_state_cb(struct qmi_result *result,
 							sim_stat.card_state);
 			data->retry_count = 0;
 			CALLBACK_WITH_FAILURE(cb, -1, cbd->data);
+			ofono_sim_inserted_notify(sim, FALSE);
 		} else {
 			DBG("Retry command");
 			retry_cbd = cb_data_new(cb, cbd->data);
@@ -639,6 +641,7 @@ static void query_passwd_state_cb(struct qmi_result *result,
 		DBG("Command failed");
 		data->retry_count = 0;
 		CALLBACK_WITH_FAILURE(cb, -1, cbd->data);
+		ofono_sim_inserted_notify(sim, FALSE);
 		break;
 	}
 }

--- a/ofono/drivers/qmimodem/sim.c
+++ b/ofono/drivers/qmimodem/sim.c
@@ -595,6 +595,10 @@ static void query_passwd_state_cb(struct qmi_result *result,
 	struct sim_status sim_stat;
 	enum get_card_status_result res;
 	struct cb_data *retry_cbd;
+	unsigned int i;
+
+	for (i = 0; i < OFONO_SIM_PASSWORD_INVALID; i++)
+		sim_stat.retries[i] = -1;
 
 	res = handle_get_card_status_result(result, &sim_stat);
 	switch (res) {
@@ -650,8 +654,12 @@ static void query_pin_retries_cb(struct qmi_result *result, void *user_data)
 	struct cb_data *cbd = user_data;
 	ofono_sim_pin_retries_cb_t cb = cbd->cb;
 	struct sim_status sim_stat;
+	unsigned int i;
 
 	DBG("");
+
+	for (i = 0; i < OFONO_SIM_PASSWORD_INVALID; i++)
+		sim_stat.retries[i] = -1;
 
 	if (handle_get_card_status_result(result, &sim_stat) !=
 					GET_CARD_STATUS_RESULT_OK) {

--- a/ofono/drivers/qmimodem/ussd.c
+++ b/ofono/drivers/qmimodem/ussd.c
@@ -251,6 +251,7 @@ static void qmi_ussd_request(struct ofono_ussd *ussd, int dcs,
 	qmi_ussd->dcs = QMI_USSD_DCS_ASCII;
 	qmi_ussd->length = len;
 	memcpy(qmi_ussd->data, utf8, utf8_len);
+	g_free(utf8);
 
 	param = qmi_param_new();
 	if (param == NULL)
@@ -265,7 +266,6 @@ static void qmi_ussd_request(struct ofono_ussd *ussd, int dcs,
 
 	qmi_param_free(param);
 error:
-	g_free(utf8);
 	g_free(cbd);
 	CALLBACK_WITH_FAILURE(cb, data);
 }

--- a/ofono/drivers/rilmodem/call-forwarding.c
+++ b/ofono/drivers/rilmodem/call-forwarding.c
@@ -38,6 +38,8 @@
 #include <ofono/call-forwarding.h>
 #include "common.h"
 
+#pragma GCC diagnostic ignored "-Wrestrict"
+
 #include "gril.h"
 
 #include "rilmodem.h"

--- a/ofono/drivers/rilmodem/lte.c
+++ b/ofono/drivers/rilmodem/lte.c
@@ -108,7 +108,8 @@ static gboolean lte_delayed_register(gpointer user_data)
 	return FALSE;
 }
 
-static int ril_lte_probe(struct ofono_lte *lte, void *user_data)
+static int ril_lte_probe(struct ofono_lte *lte,
+				unsigned int vendor, void *user_data)
 {
 	GRil *ril = user_data;
 	struct ril_lte_data *ld;

--- a/ofono/drivers/rilmodem/network-registration.c
+++ b/ofono/drivers/rilmodem/network-registration.c
@@ -37,6 +37,8 @@
 #include <ofono/modem.h>
 #include <ofono/netreg.h>
 
+#pragma GCC diagnostic ignored "-Wrestrict"
+
 #include <gril/gril.h>
 
 #include "common.h"

--- a/ofono/drivers/ubloxmodem/lte.c
+++ b/ofono/drivers/ubloxmodem/lte.c
@@ -91,7 +91,8 @@ static gboolean lte_delayed_register(gpointer user_data)
 	return FALSE;
 }
 
-static int ublox_lte_probe(struct ofono_lte *lte, void *data)
+static int ublox_lte_probe(struct ofono_lte *lte,
+					unsigned int vendor, void *data)
 {
 	GAtChat *chat = data;
 	struct lte_driver_data *ldd;

--- a/ofono/gatchat/gatmux.c
+++ b/ofono/gatchat/gatmux.c
@@ -30,6 +30,8 @@
 #include <string.h>
 #include <alloca.h>
 
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+
 #include <glib.h>
 
 #include "ringbuffer.h"

--- a/ofono/gatchat/gatmux.c
+++ b/ofono/gatchat/gatmux.c
@@ -30,6 +30,7 @@
 #include <string.h>
 #include <alloca.h>
 
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wcast-function-type"
 
 #include <glib.h>

--- a/ofono/include/lte.h
+++ b/ofono/include/lte.h
@@ -38,7 +38,7 @@ typedef void (*ofono_lte_cb_t)(const struct ofono_error *error, void *data);
 
 struct ofono_lte_driver {
 	const char *name;
-	int (*probe)(struct ofono_lte *lte, void *data);
+	int (*probe)(struct ofono_lte *lte, unsigned int vendor, void *data);
 	void (*remove)(struct ofono_lte *lte);
 	void (*set_default_attach_info)(const struct ofono_lte *lte,
 			const struct ofono_lte_default_attach_info *info,
@@ -50,6 +50,7 @@ int ofono_lte_driver_register(const struct ofono_lte_driver *d);
 void ofono_lte_driver_unregister(const struct ofono_lte_driver *d);
 
 struct ofono_lte *ofono_lte_create(struct ofono_modem *modem,
+					unsigned int vendor,
 					const char *driver, void *data);
 
 void ofono_lte_register(struct ofono_lte *lte);

--- a/ofono/plugins/gemalto.c
+++ b/ofono/plugins/gemalto.c
@@ -204,6 +204,11 @@ static void gemalto_ciev_notify(GAtResult *result, gpointer user_data)
 					NULL);
 		break;
 
+	/* USIM initialization completed. UE has finished reading USIM data. */
+	case 5:
+	        ofono_sim_initialized_notify(sim);
+		break;
+
 	default:
 		break;
 	}

--- a/ofono/plugins/gemalto.c
+++ b/ofono/plugins/gemalto.c
@@ -55,7 +55,8 @@
 
 /* Supported gemalto's modem */
 #define GEMALTO_MODEL_PHS8P 	"0053"
-#define GEMALTO_MODEL_ALS3 	"0061"
+/* ALS3, PLS8-E, and PLS8-X family */
+#define GEMALTO_MODEL_ALS3_PLS8x 	"0061"
 
 static const char *none_prefix[] = { NULL };
 static const char *sctm_prefix[] = { "^SCTM:", NULL };
@@ -591,7 +592,7 @@ static void gemalto_post_sim(struct ofono_modem *modem)
 	if (gprs && gc)
 		ofono_gprs_add_context(gprs, gc);
 
-	if (!g_strcmp0(model, GEMALTO_MODEL_ALS3))
+	if (!g_strcmp0(model, GEMALTO_MODEL_ALS3_PLS8x))
 		ofono_lte_create(modem, OFONO_VENDOR_CINTERION,
 						"atmodem", data->app);
 }

--- a/ofono/plugins/gemalto.c
+++ b/ofono/plugins/gemalto.c
@@ -54,9 +54,9 @@
 #define HARDWARE_MONITOR_INTERFACE OFONO_SERVICE ".cinterion.HardwareMonitor"
 
 /* Supported gemalto's modem */
-#define GEMALTO_MODEL_PHS8P 	"0053"
+#define GEMALTO_MODEL_PHS8P	"0053"
 /* ALS3, PLS8-E, and PLS8-X family */
-#define GEMALTO_MODEL_ALS3_PLS8x 	"0061"
+#define GEMALTO_MODEL_ALS3_PLS8x	"0061"
 
 static const char *none_prefix[] = { NULL };
 static const char *sctm_prefix[] = { "^SCTM:", NULL };
@@ -206,7 +206,7 @@ static void gemalto_ciev_notify(GAtResult *result, gpointer user_data)
 
 	/* USIM initialization completed. UE has finished reading USIM data. */
 	case 5:
-	        ofono_sim_initialized_notify(sim);
+		ofono_sim_initialized_notify(sim);
 		break;
 
 	default:

--- a/ofono/plugins/gobi.c
+++ b/ofono/plugins/gobi.c
@@ -484,7 +484,7 @@ static void gobi_post_sim(struct ofono_modem *modem)
 
 	DBG("%p", modem);
 
-	ofono_lte_create(modem, "qmimodem", data->device);
+	ofono_lte_create(modem, 0, "qmimodem", data->device);
 
 	if (data->features & GOBI_CAT)
 		ofono_stk_create(modem, 0, "qmimodem", data->device);

--- a/ofono/plugins/gobi.c
+++ b/ofono/plugins/gobi.c
@@ -264,56 +264,38 @@ static void create_shared_dms(void *user_data)
 				  create_dms_cb, modem, NULL);
 }
 
-static void discover_cb(uint8_t count, const struct qmi_version *list,
-							void *user_data)
+static void discover_cb(void *user_data)
 {
 	struct ofono_modem *modem = user_data;
 	struct gobi_data *data = ofono_modem_get_data(modem);
-	uint8_t i;
+	uint16_t major, minor;
 
 	DBG("");
 
-	for (i = 0; i < count; i++) {
-		DBG("%s %d.%d - %d", list[i].name, list[i].major, list[i].minor,
-				list[i].type);
-
-		switch (list[i].type) {
-		case QMI_SERVICE_DMS:
-			data->features |= GOBI_DMS;
-			break;
-		case QMI_SERVICE_NAS:
-			data->features |= GOBI_NAS;
-			break;
-		case QMI_SERVICE_WMS:
-			data->features |= GOBI_WMS;
-			break;
-		case QMI_SERVICE_WDS:
-			data->features |= GOBI_WDS;
-			break;
-		case QMI_SERVICE_WDA:
-			data->features |= GOBI_WDA;
-			break;
-		case QMI_SERVICE_PDS:
-			data->features |= GOBI_PDS;
-			break;
-		case QMI_SERVICE_PBM:
-			data->features |= GOBI_PBM;
-			break;
-		case QMI_SERVICE_UIM:
-			data->features |= GOBI_UIM;
-			break;
-		case QMI_SERVICE_CAT:
-			data->features |= GOBI_CAT;
-			break;
-		case QMI_SERVICE_CAT_OLD:
-			if (list[i].major > 0)
-				data->features |= GOBI_CAT_OLD;
-			break;
-		case QMI_SERVICE_VOICE:
+	if (qmi_device_has_service(data->device, QMI_SERVICE_DMS))
+		data->features |= GOBI_DMS;
+	if (qmi_device_has_service(data->device, QMI_SERVICE_NAS))
+		data->features |= GOBI_NAS;
+	if (qmi_device_has_service(data->device, QMI_SERVICE_WMS))
+		data->features |= GOBI_WMS;
+	if (qmi_device_has_service(data->device, QMI_SERVICE_WDS))
+		data->features |= GOBI_WDS;
+	if (qmi_device_has_service(data->device, QMI_SERVICE_WDA))
+		data->features |= GOBI_WDA;
+	if (qmi_device_has_service(data->device, QMI_SERVICE_PDS))
+		data->features |= GOBI_PDS;
+	if (qmi_device_has_service(data->device, QMI_SERVICE_PBM))
+		data->features |= GOBI_PBM;
+	if (qmi_device_has_service(data->device, QMI_SERVICE_UIM))
+		data->features |= GOBI_UIM;
+	if (qmi_device_has_service(data->device, QMI_SERVICE_CAT))
+		data->features |= GOBI_CAT;
+	if (qmi_device_get_service_version(data->device,
+				QMI_SERVICE_CAT_OLD, &major, &minor))
+		if (major > 0)
+			data->features |= GOBI_CAT_OLD;
+	if (qmi_device_has_service(data->device, QMI_SERVICE_VOICE))
 			data->features |= GOBI_VOICE;
-			break;
-		}
-	}
 
 	if (!(data->features & GOBI_DMS)) {
 		if (++data->discover_attempts < 3) {

--- a/ofono/plugins/mbim.c
+++ b/ofono/plugins/mbim.c
@@ -422,6 +422,8 @@ static struct ofono_modem_driver mbim_driver = {
 
 static int mbim_init(void)
 {
+	l_debug("------------------->Foobar");
+
 	return ofono_modem_driver_register(&mbim_driver);
 }
 

--- a/ofono/plugins/ril_intel.c
+++ b/ofono/plugins/ril_intel.c
@@ -458,7 +458,7 @@ static void ril_post_sim(struct ofono_modem *modem)
 	}
 
 	if (ofono_modem_get_boolean(modem, MODEM_PROP_LTE_CAPABLE))
-		ofono_lte_create(modem, "rilmodem", rd->ril);
+		ofono_lte_create(modem, 0, "rilmodem", rd->ril);
 
 	ofono_stk_create(modem, 0, "rilmodem", rd->ril);
 }

--- a/ofono/plugins/sim7100.c
+++ b/ofono/plugins/sim7100.c
@@ -1,0 +1,273 @@
+/*
+ *
+ *  oFono - Open Source Telephony
+ *
+ *  Copyright (C) 2008-2011  Intel Corporation. All rights reserved.
+ *  Copyright (C) 2009  Collabora Ltd. All rights reserved.
+ *  Copyright 2018 Purism SPC
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+/*
+ * This file was originally copied from g1.c and
+ * modified by Bob Ham <bob.ham@puri.sm>
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdlib.h>
+#include <errno.h>
+
+#include <glib.h>
+#include <gatchat.h>
+#include <gattty.h>
+
+#define OFONO_API_SUBJECT_TO_CHANGE
+#include <ofono/plugin.h>
+#include <ofono/log.h>
+#include <ofono/modem.h>
+#include <ofono/call-barring.h>
+#include <ofono/call-forwarding.h>
+#include <ofono/call-meter.h>
+#include <ofono/call-settings.h>
+#include <ofono/devinfo.h>
+#include <ofono/message-waiting.h>
+#include <ofono/netreg.h>
+#include <ofono/phonebook.h>
+#include <ofono/sim.h>
+#include <ofono/sms.h>
+#include <ofono/ussd.h>
+#include <ofono/voicecall.h>
+#include <ofono/gprs.h>
+#include <ofono/gprs-context.h>
+
+#include <drivers/atmodem/vendor.h>
+
+struct sim7100_data {
+	GAtChat *at;
+	GAtChat *ppp;
+};
+
+static void sim7100_debug(const char *str, void *user_data)
+{
+	const char *prefix = user_data;
+
+	ofono_info("%s%s", prefix, str);
+}
+
+/* Detect hardware, and initialize if found */
+static int sim7100_probe(struct ofono_modem *modem)
+{
+	struct sim7100_data *data;
+
+	DBG("");
+
+	data = g_try_new0(struct sim7100_data, 1);
+	if (data == NULL)
+		return -ENOMEM;
+
+	ofono_modem_set_data(modem, data);
+
+	return 0;
+}
+
+static void sim7100_remove(struct ofono_modem *modem)
+{
+	struct sim7100_data *data = ofono_modem_get_data(modem);
+
+	DBG("");
+
+	if (!data)
+		return;
+
+	if (data->at)
+		g_at_chat_unref(data->at);
+
+	if (data->ppp)
+		g_at_chat_unref(data->ppp);
+
+	ofono_modem_set_data(modem, NULL);
+	g_free (data);
+}
+
+static void cfun_set_on_cb(gboolean ok, GAtResult *result, gpointer user_data)
+{
+	struct ofono_modem *modem = user_data;
+
+	DBG("");
+
+	if (ok)
+		ofono_modem_set_powered(modem, TRUE);
+}
+
+static int open_device(struct ofono_modem *modem, const char *devkey,
+			GAtChat **chatp)
+{
+	GIOChannel *channel;
+	GAtSyntax *syntax;
+	GAtChat *chat;
+	const char *device;
+
+	DBG("devkey=%s", devkey);
+
+	device = ofono_modem_get_string(modem, devkey);
+	if (device == NULL)
+		return -EINVAL;
+
+	channel = g_at_tty_open(device, NULL);
+	if (channel == NULL)
+		return -EIO;
+
+	syntax = g_at_syntax_new_gsm_permissive();
+	chat = g_at_chat_new(channel, syntax);
+	g_at_syntax_unref(syntax);
+	g_io_channel_unref(channel);
+
+	if (chat == NULL)
+		return -EIO;
+
+	if (getenv("OFONO_AT_DEBUG"))
+		g_at_chat_set_debug(chat, sim7100_debug, "");
+
+	*chatp = chat;
+	return 0;
+}
+
+static int sim7100_enable(struct ofono_modem *modem)
+{
+	struct sim7100_data *data = ofono_modem_get_data(modem);
+	int err;
+
+	DBG("");
+
+	err = open_device(modem, "AT", &data->at);
+	if (err < 0)
+		return err;
+
+	err = open_device(modem, "PPP", &data->ppp);
+	if (err < 0)
+		return err;
+
+	/* ensure modem is in a known state; verbose on, echo/quiet off */
+	g_at_chat_send(data->at, "ATE0Q0V1", NULL, NULL, NULL, NULL);
+
+	/* power up modem */
+	g_at_chat_send(data->at, "AT+CFUN=1", NULL, cfun_set_on_cb,
+								modem, NULL);
+
+	return 0;
+}
+
+static void cfun_set_off_cb(gboolean ok, GAtResult *result, gpointer user_data)
+{
+	struct ofono_modem *modem = user_data;
+	struct sim7100_data *data = ofono_modem_get_data(modem);
+
+	DBG("");
+
+	g_at_chat_unref(data->ppp);
+	g_at_chat_unref(data->at);
+	data->at = data->ppp = NULL;
+
+	if (ok)
+		ofono_modem_set_powered(modem, FALSE);
+}
+
+static int sim7100_disable(struct ofono_modem *modem)
+{
+	struct sim7100_data *data = ofono_modem_get_data(modem);
+
+	DBG("");
+
+	/* power down modem */
+	g_at_chat_cancel_all(data->ppp);
+	g_at_chat_cancel_all(data->at);
+	g_at_chat_unregister_all(data->ppp);
+	g_at_chat_unregister_all(data->at);
+	g_at_chat_send(data->at, "AT+CFUN=0", NULL, cfun_set_off_cb,
+								modem, NULL);
+
+	return -EINPROGRESS;
+}
+
+static void sim7100_pre_sim(struct ofono_modem *modem)
+{
+	struct sim7100_data *data = ofono_modem_get_data(modem);
+	struct ofono_sim *sim;
+
+	DBG("");
+
+	ofono_devinfo_create(modem, 0, "atmodem", data->at);
+	sim = ofono_sim_create(modem, 0, "atmodem", data->at);
+	ofono_voicecall_create(modem, 0, "atmodem", data->at);
+
+	if (sim)
+		ofono_sim_inserted_notify(sim, TRUE);
+}
+
+static void sim7100_post_sim(struct ofono_modem *modem)
+{
+	struct sim7100_data *data = ofono_modem_get_data(modem);
+	struct ofono_message_waiting *mw;
+	struct ofono_gprs *gprs = NULL;
+	struct ofono_gprs_context *gc = NULL;
+
+	DBG("");
+
+	ofono_ussd_create(modem, 0, "atmodem", data->at);
+	ofono_call_forwarding_create(modem, 0, "atmodem", data->at);
+	ofono_call_settings_create(modem, 0, "atmodem", data->at);
+	ofono_netreg_create(modem, 0, "atmodem", data->at);
+	ofono_call_meter_create(modem, 0, "atmodem", data->at);
+	ofono_call_barring_create(modem, 0, "atmodem", data->at);
+	ofono_sms_create(modem, OFONO_VENDOR_SIMCOM, "atmodem", data->at);
+	ofono_phonebook_create(modem, 0, "atmodem", data->at);
+
+	gprs = ofono_gprs_create(modem, 0, "atmodem", data->at);
+	gc = ofono_gprs_context_create(modem, 0, "atmodem", data->ppp);
+
+	if (gprs && gc)
+		ofono_gprs_add_context(gprs, gc);
+
+	mw = ofono_message_waiting_create(modem);
+	if (mw)
+		ofono_message_waiting_register(mw);
+}
+
+static struct ofono_modem_driver sim7100_driver = {
+	.name		= "sim7100",
+	.probe		= sim7100_probe,
+	.remove		= sim7100_remove,
+	.enable		= sim7100_enable,
+	.disable	= sim7100_disable,
+	.pre_sim	= sim7100_pre_sim,
+	.post_sim	= sim7100_post_sim,
+};
+
+static int sim7100_init(void)
+{
+	return ofono_modem_driver_register(&sim7100_driver);
+}
+
+static void sim7100_exit(void)
+{
+	ofono_modem_driver_unregister(&sim7100_driver);
+}
+
+OFONO_PLUGIN_DEFINE(sim7100, "SIMCom SIM7100E modem driver", VERSION,
+		OFONO_PLUGIN_PRIORITY_DEFAULT, sim7100_init, sim7100_exit)

--- a/ofono/plugins/sim7100.c
+++ b/ofono/plugins/sim7100.c
@@ -214,7 +214,7 @@ static void sim7100_pre_sim(struct ofono_modem *modem)
 
 	ofono_devinfo_create(modem, 0, "atmodem", data->at);
 	sim = ofono_sim_create(modem, 0, "atmodem", data->at);
-	ofono_voicecall_create(modem, 0, "atmodem", data->at);
+	ofono_voicecall_create(modem, OFONO_VENDOR_SIMCOM, "atmodem", data->at);
 
 	if (sim)
 		ofono_sim_inserted_notify(sim, TRUE);

--- a/ofono/plugins/ublox.c
+++ b/ofono/plugins/ublox.c
@@ -319,7 +319,7 @@ static void ublox_post_sim(struct ofono_modem *modem)
 		--ncontexts;
 	}
 
-	ofono_lte_create(modem, "ubloxmodem", data->aux);
+	ofono_lte_create(modem, 0, "ubloxmodem", data->aux);
 }
 
 static void ublox_post_online(struct ofono_modem *modem)

--- a/ofono/plugins/udevng.c
+++ b/ofono/plugins/udevng.c
@@ -1670,8 +1670,8 @@ static struct {
 	{ "gemalto",	"cdc_ether",	"1e2d",	"0061"	},
 	{ "telit",	"cdc_ncm",	"1bc7", "0036"	},
 	{ "telit",	"cdc_acm",	"1bc7", "0036"	},
-	{ "xmm7xxx",	"cdc_acm",	"8087", "0930"	},
-	{ "xmm7xxx",	"cdc_ncm",	"8087", "0930"	},
+	{ "xmm7xxx",	"cdc_acm",	"8087"		},
+	{ "xmm7xxx",	"cdc_ncm",	"8087"		},
 	{ }
 };
 

--- a/ofono/plugins/udevng.c
+++ b/ofono/plugins/udevng.c
@@ -1801,7 +1801,11 @@ static gboolean create_modem(gpointer key, gpointer value, gpointer user_data)
 		if (driver_list[i].setup(modem) == TRUE) {
 			ofono_modem_set_string(modem->modem, "SystemPath",
 								syspath);
-			ofono_modem_register(modem->modem);
+			if (ofono_modem_register(modem->modem) < 0) {
+				DBG("could not register modem '%s'", modem->driver);
+				return TRUE;
+			}
+
 			return FALSE;
 		}
 	}

--- a/ofono/plugins/udevng.c
+++ b/ofono/plugins/udevng.c
@@ -1132,6 +1132,7 @@ static gboolean setup_gemalto(struct modem_info* modem)
 		DBG("%s %s %s %s %s", info->devnode, info->interface,
 				info->number, info->label, info->subsystem);
 
+		/* PHS8-P */
 		if (g_strcmp0(info->interface, "255/255/255") == 0) {
 			if (g_strcmp0(info->number, "01") == 0)
 				gps = info->devnode;
@@ -1143,6 +1144,20 @@ static gboolean setup_gemalto(struct modem_info* modem)
 				net = info->devnode;
 			else if (g_strcmp0(info->subsystem, "usbmisc") == 0)
 				qmi = info->devnode;
+		}
+
+		/* ALS3 */
+		if (g_strcmp0(info->interface, "2/2/1") == 0) {
+			if (g_strcmp0(info->number, "00") == 0)
+				mdm = info->devnode;
+			else if (g_strcmp0(info->number, "02") == 0)
+				app = info->devnode;
+			else if (g_strcmp0(info->number, "04") == 0)
+				gps = info->devnode;
+		}
+		if (g_strcmp0(info->interface, "2/6/0") == 0) {
+			if (g_strcmp0(info->subsystem, "net") == 0)
+				net = info->devnode;
 		}
 	}
 
@@ -1156,6 +1171,7 @@ static gboolean setup_gemalto(struct modem_info* modem)
 	ofono_modem_set_string(modem->modem, "GPS", gps);
 	ofono_modem_set_string(modem->modem, "Modem", mdm);
 	ofono_modem_set_string(modem->modem, "Device", qmi);
+	ofono_modem_set_string(modem->modem, "Model", modem->model);
 	ofono_modem_set_string(modem->modem, "NetworkInterface", net);
 
 	return TRUE;
@@ -1600,6 +1616,8 @@ static struct {
 	{ "gemalto",	"option",	"1e2d",	"0053"	},
 	{ "gemalto",	"cdc_wdm",	"1e2d",	"0053"	},
 	{ "gemalto",	"qmi_wwan",	"1e2d",	"0053"	},
+	{ "gemalto",	"cdc_acm",	"1e2d",	"0061"	},
+	{ "gemalto",	"cdc_ether",	"1e2d",	"0061"	},
 	{ "telit",	"cdc_ncm",	"1bc7", "0036"	},
 	{ "telit",	"cdc_acm",	"1bc7", "0036"	},
 	{ "xmm7xxx",	"cdc_acm",	"8087", "0930"	},

--- a/ofono/plugins/udevng.c
+++ b/ofono/plugins/udevng.c
@@ -1146,7 +1146,7 @@ static gboolean setup_gemalto(struct modem_info* modem)
 				qmi = info->devnode;
 		}
 
-		/* ALS3 */
+		/* Cinterion ALS3, PLS8-E, PLS8-X */
 		if (g_strcmp0(info->interface, "2/2/1") == 0) {
 			if (g_strcmp0(info->number, "00") == 0)
 				mdm = info->devnode;

--- a/ofono/plugins/xmm7xxx.c
+++ b/ofono/plugins/xmm7xxx.c
@@ -323,7 +323,7 @@ static void xmm7xxx_post_sim(struct ofono_modem *modem)
 {
 	struct xmm7xxx_data *data = ofono_modem_get_data(modem);
 
-	ofono_lte_create(modem, "atmodem", data->chat);
+	ofono_lte_create(modem, 0, "atmodem", data->chat);
 	ofono_radio_settings_create(modem, 0, "xmm7modem", data->chat);
 	ofono_sim_auth_create(modem);
 }

--- a/ofono/src/cdma-netreg.c
+++ b/ofono/src/cdma-netreg.c
@@ -115,6 +115,8 @@ static const GDBusMethodTable cdma_netreg_manager_methods[] = {
 };
 
 static const GDBusSignalTable cdma_netreg_manager_signals[] = {
+	{ GDBUS_SIGNAL("PropertyChanged",
+		GDBUS_ARGS({ "name", "s" }, { "value", "v" })) },
 	{ }
 };
 

--- a/ofono/src/lte.c
+++ b/ofono/src/lte.c
@@ -244,6 +244,7 @@ static void lte_atom_remove(struct ofono_atom *atom)
 }
 
 struct ofono_lte *ofono_lte_create(struct ofono_modem *modem,
+					unsigned int vendor,
 					const char *driver, void *data)
 {
 	struct ofono_lte *lte;
@@ -266,7 +267,7 @@ struct ofono_lte *ofono_lte_create(struct ofono_modem *modem,
 		if (g_strcmp0(drv->name, driver))
 			continue;
 
-		if (drv->probe(lte, data) < 0)
+		if (drv->probe(lte, vendor, data) < 0)
 			continue;
 
 		lte->driver = drv;

--- a/ofono/src/sim.c
+++ b/ofono/src/sim.c
@@ -960,7 +960,8 @@ static void sim_enter_pin_cb(const struct ofono_error *error, void *data)
 
 	__ofono_dbus_pending_reply(&sim->pending, reply);
 
-	if (sim->initialized)
+	/* If PIN entry fails, then recheck the PIN type */
+	if (sim->initialized || error->type != OFONO_ERROR_TYPE_NO_ERROR)
 		goto recheck;
 
 	if (sim->pin_type == OFONO_SIM_PASSWORD_SIM_PIN ||

--- a/ofono/unit/test-mbim.c
+++ b/ofono/unit/test-mbim.c
@@ -329,7 +329,7 @@ static void parse_device_caps(const void *data)
 	assert(r);
 
 	assert(device_type == 1);
-	assert(cellular_class = 1);
+	assert(cellular_class == 1);
 	assert(voice_class == 1);
 	assert(sim_class == 2);
 	assert(data_class == 0x3f);

--- a/rpm/ofono.spec
+++ b/rpm/ofono.spec
@@ -1,6 +1,6 @@
 Name:       ofono
 Summary:    Open Source Telephony
-Version:    1.23
+Version:    1.24
 Release:    1
 License:    GPLv2
 URL:        https://git.sailfishos.org/mer-core/ofono


### PR DESCRIPTION
This pull request contains all cherry-picked commits between release 1.23, which is in use by Sailfish OS right now, and 1.24 in upstream Ofono. All cherry-picked commits were applied cleanly, without any manual intervention necessary, so I do not expect any real problems. At least It has already been verified that the package compiles properly. I can only test the package on a PinePhone, so if others will test it on their devices/builds please let me know if there are any regressions.