### PR TITLE
Fix double-free

### DIFF
--- a/ofono/drivers/ril/ril_cell_info.c
+++ b/ofono/drivers/ril/ril_cell_info.c
@@ -113,7 +113,7 @@ static void ril_cell_info_update_cells(RilCellInfo *self, GPtrArray *l)
 	if (l && !ril_cell_info_list_identical(self->cells,
 		(struct ofono_cell **)l->pdata)) {
 		gutil_ptrv_free((void**)self->cells);
-		self->info.cells = (struct ofono_cell **)
+		self->info.cells = self->cells = (struct ofono_cell **)
 			g_ptr_array_free(l, FALSE);
 		g_signal_emit(self, ril_cell_info_signals
 			[SIGNAL_CELLS_CHANGED], 0);


### PR DESCRIPTION
```
==26985== Invalid read of size 8
==26985==    at 0x4210DC: ril_cell_info_list_identical (ril_cell_info.c:97)
==26985==    by 0x4210DC: ril_cell_info_update_cells (ril_cell_info.c:113)
==26985==    by 0x4B342AF: grilio_channel_handle_response (grilio_channel.c:1193)
==26985==    by 0x4E44F3B: ffi_call_SYSV (in /usr/lib64/libffi.so.6.0.4)
==26985==    by 0x4E4580B: ffi_call (in /usr/lib64/libffi.so.6.0.4)
==26985==    by 0x48DB153: g_cclosure_marshal_generic_va (gclosure.c:1614)
==26985==    by 0x48DA807: _g_closure_invoke_va (gclosure.c:873)
==26985==    by 0x48F8517: g_signal_emit_valist (gsignal.c:3403)
==26985==    by 0x48F8947: g_signal_emit (gsignal.c:3550)
==26985==    by 0x58FA403: ril_binder_radio_decode_response (ril_binder_radio.c:4627)
==26985==    by 0x58FA50F: ril_binder_radio_handle_known_response (ril_binder_radio.c:4255)
==26985==    by 0x58FA50F: ril_binder_radio_handle_response (ril_binder_radio.c:4427)
==26985==    by 0x4E44F3B: ffi_call_SYSV (in /usr/lib64/libffi.so.6.0.4)
==26985==    by 0x4E4580B: ffi_call (in /usr/lib64/libffi.so.6.0.4)
==26985==    by 0x48DB153: g_cclosure_marshal_generic_va (gclosure.c:1614)
==26985==    by 0x48DA807: _g_closure_invoke_va (gclosure.c:873)
==26985==    by 0x48F7887: g_signal_emit_valist (gsignal.c:3403)
==26985==    by 0x48F8947: g_signal_emit (gsignal.c:3550)
==26985==    by 0x58B126B: radio_instance_response (radio_instance.c:289)
==26985==    by 0x5889BEF: gbinder_ipc_looper_tx_handle (gbinder_ipc.c:491)
==26985==    by 0x5887CFF: gbinder_eventloop_glib_callback_dispatch (gbinder_eventloop.c:152)
==26985==    by 0x498B103: g_main_dispatch (gmain.c:3325)
==26985==    by 0x498B103: g_main_context_dispatch (gmain.c:4016)
==26985==  Address 0x651bf50 is 0 bytes inside a block of size 8 free'd
==26985==    at 0x4868620: free (vg_replace_malloc.c:540)
==26985==    by 0x421103: ril_cell_info_update_cells (ril_cell_info.c:115)
==26985==    by 0x4B342AF: grilio_channel_handle_response (grilio_channel.c:1193)
==26985==    by 0x4E44F3B: ffi_call_SYSV (in /usr/lib64/libffi.so.6.0.4)
==26985==    by 0x4E4580B: ffi_call (in /usr/lib64/libffi.so.6.0.4)
==26985==    by 0x48DB153: g_cclosure_marshal_generic_va (gclosure.c:1614)
==26985==    by 0x48DA807: _g_closure_invoke_va (gclosure.c:873)
==26985==    by 0x48F8517: g_signal_emit_valist (gsignal.c:3403)
==26985==    by 0x48F8947: g_signal_emit (gsignal.c:3550)
==26985==    by 0x58FA403: ril_binder_radio_decode_response (ril_binder_radio.c:4627)
==26985==    by 0x58FA50F: ril_binder_radio_handle_known_response (ril_binder_radio.c:4255)
==26985==    by 0x58FA50F: ril_binder_radio_handle_response (ril_binder_radio.c:4427)
==26985==    by 0x4E44F3B: ffi_call_SYSV (in /usr/lib64/libffi.so.6.0.4)
==26985==    by 0x4E4580B: ffi_call (in /usr/lib64/libffi.so.6.0.4)
==26985==    by 0x48DB153: g_cclosure_marshal_generic_va (gclosure.c:1614)
==26985==    by 0x48DA807: _g_closure_invoke_va (gclosure.c:873)
==26985==    by 0x48F7887: g_signal_emit_valist (gsignal.c:3403)
==26985==    by 0x48F8947: g_signal_emit (gsignal.c:3550)
==26985==    by 0x58B126B: radio_instance_response (radio_instance.c:289)
==26985==    by 0x5889BEF: gbinder_ipc_looper_tx_handle (gbinder_ipc.c:491)
==26985==    by 0x5887CFF: gbinder_eventloop_glib_callback_dispatch (gbinder_eventloop.c:152)
==26985==  Block was alloc'd at
==26985==    at 0x48697A4: calloc (vg_replace_malloc.c:762)
==26985==    by 0x4990D7F: g_malloc0 (gmem.c:136)
==26985==    by 0x4203AF: ril_cell_info_init (ril_cell_info.c:563)
==26985==    by 0x48FF86F: g_type_create_instance (gtype.c:1867)
==26985==    by 0x48E012F: g_object_new_internal (gobject.c:1939)
==26985==    by 0x48E1A4B: g_object_new_with_properties (gobject.c:2107)
==26985==    by 0x48E2347: g_object_new (gobject.c:1779)
==26985==    by 0x4218C7: ril_cell_info_new (ril_cell_info.c:524)
==26985==    by 0x432233: ril_plugin_slot_connected (ril_plugin.c:1081)
==26985==    by 0x48DA807: _g_closure_invoke_va (gclosure.c:873)
==26985==    by 0x48F8517: g_signal_emit_valist (gsignal.c:3403)
==26985==    by 0x48F8947: g_signal_emit (gsignal.c:3550)
==26985==    by 0x4B339C7: grilio_channel_handle_connected (grilio_channel.c:626)
==26985==    by 0x48DA807: _g_closure_invoke_va (gclosure.c:873)
==26985==    by 0x48F8517: g_signal_emit_valist (gsignal.c:3403)
==26985==    by 0x48F8947: g_signal_emit (gsignal.c:3550)
==26985==    by 0x58FA867: ril_binder_radio_handle_indication (ril_binder_radio.c:4446)
==26985==    by 0x4E44F3B: ffi_call_SYSV (in /usr/lib64/libffi.so.6.0.4)
==26985==    by 0x4E4580B: ffi_call (in /usr/lib64/libffi.so.6.0.4)
==26985==    by 0x48DB153: g_cclosure_marshal_generic_va (gclosure.c:1614)
```