### PR TITLE
[packaging] BuildRequire systemd via pkgconfig. JB#55010

### DIFF
--- a/rpm/ofono.spec
+++ b/rpm/ofono.spec
@@ -28,10 +28,10 @@ BuildRequires:  pkgconfig(libglibutil) >= %{libglibutil_version}
 BuildRequires:  pkgconfig(libdbuslogserver-dbus)
 BuildRequires:  pkgconfig(libdbusaccess)
 BuildRequires:  pkgconfig(mobile-broadband-provider-info)
+BuildRequires:  pkgconfig(systemd)
 BuildRequires:  libtool
 BuildRequires:  automake
 BuildRequires:  autoconf
-BuildRequires:  systemd
 
 %description
 Telephony stack


### PR DESCRIPTION
This allows to pick systemd-mini inside the builder instead of full
systemd.