### PR TITLE
Add ofono_cell_info based NetMon driver

### DIFF
--- a/ofono/.gitignore
+++ b/ofono/.gitignore
@@ -43,6 +43,7 @@ unit/test-simutil
 unit/test-mux
 unit/test-caif
 unit/test-cell-info
+unit/test-cell-info-control
 unit/test-cell-info-dbus
 unit/test-stkutil
 unit/test-cdmasms

--- a/ofono/Makefile.am
+++ b/ofono/Makefile.am
@@ -113,8 +113,8 @@ gril_sources = gril/gril.h gril/gril.c \
 
 btio_sources = btio/btio.h btio/btio.c
 
-builtin_modules += generic_phonebook
-builtin_sources += plugins/generic-phonebook.c
+builtin_modules += cellinfo_netmon generic_phonebook
+builtin_sources += plugins/cellinfo-netmon.c plugins/generic-phonebook.c
 
 if UDEV
 builtin_cflags += @UDEV_CFLAGS@
@@ -726,6 +726,7 @@ src_ofonod_SOURCES = $(builtin_sources) $(gatchat_sources) src/ofono.ver \
 			src/netmonagent.c src/netmonagent.h \
 			src/slot-manager.c src/slot-manager-dbus.c \
 			src/cell-info.c src/cell-info-dbus.c \
+			src/cell-info-control.c \
 			src/sim-info.c src/sim-info-dbus.c \
 			src/conf.c src/mtu-limit.c
 
@@ -926,11 +927,19 @@ unit_test_cell_info_LDADD = @GLIB_LIBS@ -ldl
 unit_objects += $(unit_test_cell_info_OBJECTS)
 unit_tests += unit/test-cell-info
 
+unit_test_cell_info_control_SOURCES = unit/test-cell-info-control.c \
+			unit/fake_cell_info.c src/cell-info.c \
+			src/cell-info-control.c src/log.c
+unit_test_cell_info_control_CFLAGS = $(AM_CFLAGS) $(COVERAGE_OPT)
+unit_test_cell_info_control_LDADD = @GLIB_LIBS@ -ldl
+unit_objects += $(unit_test_cell_info_control_OBJECTS)
+unit_tests += unit/test-cell-info-control
+
 unit_test_cell_info_dbus_SOURCES = unit/test-dbus.c \
 			unit/test-cell-info-dbus.c unit/fake_cell_info.c \
 			src/cell-info.c src/cell-info-dbus.c \
-			gdbus/object.c src/dbus-clients.c \
-			src/dbus.c src/log.c
+			src/cell-info-control.c gdbus/object.c \
+			src/dbus-clients.c src/dbus.c src/log.c
 unit_test_cell_info_dbus_CFLAGS = $(AM_CFLAGS) $(COVERAGE_OPT) \
 			@DBUS_GLIB_CFLAGS@
 unit_test_cell_info_dbus_LDADD = @DBUS_GLIB_LIBS@ @GLIB_LIBS@ -ldl
@@ -957,8 +966,9 @@ unit_objects += $(unit_test_sim_info_dbus_OBJECTS)
 unit_tests += unit/test-sim-info-dbus
 
 unit_test_slot_manager_SOURCES = unit/test-slot-manager.c unit/fake_watch.c \
-			src/slot-manager.c src/cell-info.c src/sim-info.c \
-			src/storage.c src/log.c
+			unit/fake_cell_info.c src/slot-manager.c \
+			src/cell-info.c src/cell-info-control.c \
+			src/sim-info.c src/storage.c src/log.c
 unit_test_slot_manager_CFLAGS = $(AM_CFLAGS) $(COVERAGE_OPT) \
 			-DSTORAGEDIR='"/tmp/ofono"'
 unit_test_slot_manager_LDADD = @GLIB_LIBS@ -ldl
@@ -966,6 +976,7 @@ unit_objects += $(unit_test_slot_manager_OBJECTS)
 unit_tests += unit/test-slot-manager
 
 unit_test_watch_SOURCES = unit/test-watch.c src/watch.c \
+			src/cell-info.c src/cell-info-control.c \
 			src/log.c src/watchlist.c
 unit_test_watch_CFLAGS = $(AM_CFLAGS) $(COVERAGE_OPT) \
 			-DSTORAGEDIR='"/tmp/ofono"'

--- a/ofono/include/slot.h
+++ b/ofono/include/slot.h
@@ -152,8 +152,14 @@ void ofono_slot_remove_handlers(struct ofono_slot *s, unsigned long *ids,
 void ofono_slot_set_sim_presence(struct ofono_slot *s,
 	enum ofono_slot_sim_presence sim_presence);
 
-#define ofono_slot_remove_all_handlers(s, ids) /* Since mer/1.25+git5 */\
+/* Since mer/1.25+git5 */
+#define ofono_slot_remove_all_handlers(s, ids) \
 	ofono_slot_remove_handlers(s, ids, G_N_ELEMENTS(ids))
+
+/* Since mer/1.25+git7 */
+void ofono_slot_set_cell_info_update_interval(struct ofono_slot *s, void* tag,
+	int interval_ms);
+void ofono_slot_drop_cell_info_requests(struct ofono_slot *s, void* tag);
 
 #ifdef __cplusplus
 }

--- a/ofono/plugins/cellinfo-netmon.c
+++ b/ofono/plugins/cellinfo-netmon.c
@@ -1,0 +1,487 @@
+/*
+ *  oFono - Open Source Telephony
+ *
+ *  Copyright (C) 2021 Jolla Ltd.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ */
+
+#include "ofono.h"
+#include "cell-info-control.h"
+
+#include <ofono/cell-info.h>
+#include <ofono/log.h>
+#include <ofono/modem.h>
+#include <ofono/netmon.h>
+#include <ofono/plugin.h>
+#include <ofono/sim-mnclength.h>
+
+#include <glib.h>
+
+#include <stdio.h>
+
+struct cellinfo_netmon_data {
+	struct ofono_netmon *netmon;
+	CellInfoControl *ctl;
+	guint register_id;
+	guint update_id;
+};
+
+struct cellinfo_netmon_update_cbd {
+	struct cellinfo_netmon_data *nm;
+	struct ofono_cell_info *info;
+	unsigned long event_id;
+	ofono_netmon_cb_t cb;
+	void *data;
+};
+
+#define CALLBACK_WITH_SUCCESS(f, args...)		\
+	do {						\
+		struct ofono_error e;			\
+		e.type = OFONO_ERROR_TYPE_NO_ERROR;	\
+		e.error = 0;				\
+		f(&e, ##args);				\
+	} while (0)
+
+#define NETMON_UPDATE_INTERVAL_MS 500
+#define NETMON_UPDATE_SHORT_TIMEOUT_MS 10000
+#define NETMON_UPDATE_LONG_TIMEOUT_MS 10000
+
+/* This number must be in sync with cellinfo_netmon_notify: */
+#define NETMON_MAX_OFONO_PARAMS (8)
+
+struct cellinfo_netmon_notify_param {
+	enum ofono_netmon_info type;
+	int value;
+};
+
+static inline struct cellinfo_netmon_data *
+cellinfo_netmon_get_data(struct ofono_netmon *ofono)
+{
+	return ofono ? ofono_netmon_get_data(ofono) : NULL;
+}
+
+static void cellinfo_netmon_format_mccmnc(char *s_mcc, char *s_mnc,
+		int mcc, int mnc)
+{
+	s_mcc[0] = 0;
+	s_mnc[0] = 0;
+
+	if (mcc >= 0 && mcc <= 999) {
+		snprintf(s_mcc, OFONO_MAX_MCC_LENGTH + 1, "%03d", mcc);
+		if (mnc >= 0 && mnc <= 999) {
+			const int mnclen =
+				ofono_sim_mnclength_get_mnclength_mccmnc(mcc,
+									mnc);
+
+			if (mnclen >= 0) {
+				snprintf(s_mnc, OFONO_MAX_MNC_LENGTH, "%0*d",
+								mnclen, mnc);
+				s_mnc[OFONO_MAX_MNC_LENGTH] = 0;
+			}
+		}
+	}
+}
+
+static void cellinfo_netmon_notify(struct ofono_netmon *netmon,
+		enum ofono_netmon_cell_type type, int mcc, int mnc,
+		struct cellinfo_netmon_notify_param *params, int nparams)
+{
+	char s_mcc[OFONO_MAX_MCC_LENGTH + 1];
+	char s_mnc[OFONO_MAX_MNC_LENGTH + 1];
+	int i;
+
+	/* Better not to push uninitialized data to the stack ... */
+	for (i = nparams; i < NETMON_MAX_OFONO_PARAMS; i++) {
+		params[i].type = OFONO_NETMON_INFO_INVALID;
+		params[i].value = OFONO_CELL_INVALID_VALUE;
+	}
+
+	cellinfo_netmon_format_mccmnc(s_mcc, s_mnc, mcc, mnc);
+	ofono_netmon_serving_cell_notify(netmon, type,
+		OFONO_NETMON_INFO_MCC, s_mcc,
+		OFONO_NETMON_INFO_MNC, s_mnc,
+		params[0].type, params[0].value,
+		params[1].type, params[1].value,
+		params[2].type, params[2].value,
+		params[3].type, params[3].value,
+		params[4].type, params[4].value,
+		params[5].type, params[5].value,
+		params[6].type, params[6].value,
+		params[7].type, params[7].value,
+		OFONO_NETMON_INFO_INVALID);
+}
+
+static void cellinfo_netmon_notify_gsm(struct ofono_netmon *netmon,
+		const struct ofono_cell_info_gsm *gsm)
+{
+	struct cellinfo_netmon_notify_param params[NETMON_MAX_OFONO_PARAMS];
+	int n = 0;
+
+	if (gsm->lac != OFONO_CELL_INVALID_VALUE) {
+		params[n].type = OFONO_NETMON_INFO_LAC;
+		params[n].value = gsm->lac;
+		n++;
+	}
+
+	if (gsm->cid != OFONO_CELL_INVALID_VALUE) {
+		params[n].type = OFONO_NETMON_INFO_CI;
+		params[n].value = gsm->cid;
+		n++;
+	}
+
+	if (gsm->arfcn != OFONO_CELL_INVALID_VALUE) {
+		params[n].type = OFONO_NETMON_INFO_ARFCN;
+		params[n].value = gsm->arfcn;
+		n++;
+	}
+
+	if (gsm->signalStrength != OFONO_CELL_INVALID_VALUE) {
+		params[n].type = OFONO_NETMON_INFO_RSSI;
+		params[n].value = gsm->signalStrength;
+		n++;
+	}
+
+	if (gsm->bitErrorRate != OFONO_CELL_INVALID_VALUE) {
+		params[n].type = OFONO_NETMON_INFO_BER;
+		params[n].value = gsm->bitErrorRate;
+		n++;
+	}
+
+	cellinfo_netmon_notify(netmon, OFONO_NETMON_CELL_TYPE_GSM,
+		gsm->mcc, gsm->mnc, params, n);
+}
+
+static void cellinfo_netmon_notify_wcdma(struct ofono_netmon *netmon,
+		const struct ofono_cell_info_wcdma *wcdma)
+{
+	struct cellinfo_netmon_notify_param params[NETMON_MAX_OFONO_PARAMS];
+	int n = 0;
+
+	if (wcdma->lac != OFONO_CELL_INVALID_VALUE) {
+		params[n].type = OFONO_NETMON_INFO_LAC;
+		params[n].value = wcdma->lac;
+		n++;
+	}
+
+	if (wcdma->cid != OFONO_CELL_INVALID_VALUE) {
+		params[n].type = OFONO_NETMON_INFO_CI;
+		params[n].value = wcdma->cid;
+		n++;
+	}
+
+	if (wcdma->psc != OFONO_CELL_INVALID_VALUE) {
+		params[n].type = OFONO_NETMON_INFO_PSC;
+		params[n].value = wcdma->psc;
+		n++;
+	}
+
+	if (wcdma->uarfcn != OFONO_CELL_INVALID_VALUE) {
+		params[n].type = OFONO_NETMON_INFO_ARFCN;
+		params[n].value = wcdma->uarfcn;
+		n++;
+	}
+
+	if (wcdma->signalStrength != OFONO_CELL_INVALID_VALUE) {
+		params[n].type = OFONO_NETMON_INFO_RSSI;
+		params[n].value = wcdma->signalStrength;
+		n++;
+	}
+
+	if (wcdma->bitErrorRate != OFONO_CELL_INVALID_VALUE) {
+		params[n].type = OFONO_NETMON_INFO_BER;
+		params[n].value = wcdma->bitErrorRate;
+		n++;
+	}
+
+	cellinfo_netmon_notify(netmon, OFONO_NETMON_CELL_TYPE_UMTS,
+		wcdma->mcc, wcdma->mnc, params, n);
+}
+
+static void cellinfo_netmon_notify_lte(struct ofono_netmon *netmon,
+		const struct ofono_cell_info_lte *lte)
+{
+	struct cellinfo_netmon_notify_param params[NETMON_MAX_OFONO_PARAMS];
+	int n = 0;
+
+	if (lte->ci != OFONO_CELL_INVALID_VALUE) {
+		params[n].type = OFONO_NETMON_INFO_CI;
+		params[n].value = lte->ci;
+		n++;
+	}
+
+	if (lte->earfcn != OFONO_CELL_INVALID_VALUE) {
+		params[n].type = OFONO_NETMON_INFO_EARFCN;
+		params[n].value = lte->earfcn;
+		n++;
+	}
+
+	if (lte->signalStrength != OFONO_CELL_INVALID_VALUE) {
+		params[n].type = OFONO_NETMON_INFO_RSSI;
+		params[n].value = lte->signalStrength;
+		n++;
+	}
+
+	if (lte->rsrp != OFONO_CELL_INVALID_VALUE) {
+		params[n].type = OFONO_NETMON_INFO_RSRQ;
+		params[n].value = lte->rsrp;
+		n++;
+	}
+
+	if (lte->rsrq != OFONO_CELL_INVALID_VALUE) {
+		params[n].type = OFONO_NETMON_INFO_RSRP;
+		params[n].value = lte->rsrq;
+		n++;
+	}
+
+	if (lte->cqi != OFONO_CELL_INVALID_VALUE) {
+		params[n].type = OFONO_NETMON_INFO_CQI;
+		params[n].value = lte->cqi;
+		n++;
+	}
+
+	if (lte->timingAdvance != OFONO_CELL_INVALID_VALUE) {
+		params[n].type = OFONO_NETMON_INFO_TIMING_ADVANCE;
+		params[n].value = lte->timingAdvance;
+		n++;
+	}
+
+	cellinfo_netmon_notify(netmon, OFONO_NETMON_CELL_TYPE_LTE,
+		lte->mcc, lte->mnc, params, n);
+}
+
+static gboolean cellinfo_netmon_notify_cell(struct ofono_netmon *netmon,
+		const struct ofono_cell *cell)
+{
+	if (cell->registered) {
+		switch (cell->type) {
+		case OFONO_CELL_TYPE_GSM:
+			cellinfo_netmon_notify_gsm(netmon, &cell->info.gsm);
+			return TRUE;
+		case OFONO_CELL_TYPE_WCDMA:
+			cellinfo_netmon_notify_wcdma(netmon, &cell->info.wcdma);
+			return TRUE;
+		case OFONO_CELL_TYPE_LTE:
+			cellinfo_netmon_notify_lte(netmon, &cell->info.lte);
+			return TRUE;
+		default:
+			break;
+		}
+	}
+	return FALSE;
+}
+
+static guint cellinfo_netmon_notify_cells(struct ofono_netmon *netmon,
+		struct ofono_cell_info *info)
+{
+	guint n = 0;
+
+	if (info && info->cells) {
+		const ofono_cell_ptr *ptr;
+
+		for (ptr = info->cells; *ptr; ptr++) {
+			if (cellinfo_netmon_notify_cell(netmon, *ptr)) {
+				/*
+				 * We could actually break here because
+				 * there shouldn't be more than one cell
+				 * in a registered state...
+				 */
+				n++;
+			}
+		}
+	}
+
+	return n;
+}
+
+static gboolean cellinfo_netmon_have_registered_cells
+		(struct ofono_cell_info *info)
+{
+	if (info && info->cells) {
+		const ofono_cell_ptr *ptr;
+
+		for (ptr = info->cells; *ptr; ptr++) {
+			if ((*ptr)->registered) {
+				return TRUE;
+			}
+		}
+	}
+
+	return FALSE;
+}
+
+static void cellinfo_netmon_request_update_event(struct ofono_cell_info *info,
+		void *user_data)
+{
+	struct cellinfo_netmon_update_cbd *cbd = user_data;
+	struct cellinfo_netmon_data *nm = cbd->nm;
+
+	if (cellinfo_netmon_notify_cells(nm->netmon, info)) {
+		ofono_netmon_cb_t cb = cbd->cb;
+		void *data = cbd->data;
+
+		/* Removing the source destroys cellinfo_netmon_update_cbd */
+		DBG("%s received update", nm->ctl->path);
+		g_source_remove(nm->update_id);
+		nm->update_id = 0;
+		CALLBACK_WITH_SUCCESS(cb, data);
+	}
+}
+
+static gboolean cellinfo_netmon_request_update_timeout(gpointer data)
+{
+	struct cellinfo_netmon_update_cbd *cbd = data;
+	struct cellinfo_netmon_data *nm = cbd->nm;
+
+	nm->update_id = 0;
+	DBG("%s update timed out", nm->ctl->path);
+	CALLBACK_WITH_SUCCESS(cbd->cb, cbd->data);
+	return G_SOURCE_REMOVE;
+}
+
+static void cellinfo_netmon_request_update_destroy(gpointer data)
+{
+	struct cellinfo_netmon_update_cbd *cbd = data;
+	struct cellinfo_netmon_data *nm = cbd->nm;
+
+	cell_info_control_drop_requests(nm->ctl, cbd);
+	ofono_cell_info_remove_handler(cbd->info, cbd->event_id);
+	ofono_cell_info_unref(cbd->info);
+	g_free(cbd);
+}
+
+static void cellinfo_netmon_request_update(struct ofono_netmon *netmon,
+		ofono_netmon_cb_t cb, void *data)
+{
+	struct cellinfo_netmon_data *nm = cellinfo_netmon_get_data(netmon);
+	struct ofono_cell_info *info = nm->ctl->info;
+	struct cellinfo_netmon_update_cbd *cbd =
+		g_new(struct cellinfo_netmon_update_cbd, 1);
+
+	cbd->cb = cb;
+	cbd->data = data;
+	cbd->nm = nm;
+	cbd->info = ofono_cell_info_ref(info);
+	cbd->event_id = ofono_cell_info_add_change_handler(info,
+				cellinfo_netmon_request_update_event, cbd);
+
+	/* Temporarily enable updates and wait */
+	DBG("%s waiting for update", nm->ctl->path);
+	cell_info_control_set_update_interval(nm->ctl, cbd,
+				NETMON_UPDATE_INTERVAL_MS);
+	cell_info_control_set_enabled(nm->ctl, cbd, TRUE);
+
+	/* Use shorter timeout if we already have something */
+	nm->update_id = g_timeout_add_full(G_PRIORITY_DEFAULT_IDLE,
+				cellinfo_netmon_have_registered_cells(info) ?
+				NETMON_UPDATE_SHORT_TIMEOUT_MS :
+				NETMON_UPDATE_LONG_TIMEOUT_MS,
+				cellinfo_netmon_request_update_timeout,
+				cbd, cellinfo_netmon_request_update_destroy);
+}
+
+static void cellinfo_netmon_enable_periodic_update(struct ofono_netmon *netmon,
+		unsigned int enable, unsigned int period_sec,
+		ofono_netmon_cb_t cb, void *data)
+{
+	struct cellinfo_netmon_data *nm = cellinfo_netmon_get_data(netmon);
+	CellInfoControl *ctl = nm->ctl;
+
+	if (ctl) {
+		const int ms = period_sec * 1000;
+
+		if (enable) {
+			cell_info_control_set_update_interval(ctl, nm, ms);
+			cell_info_control_set_enabled(ctl, nm, TRUE);
+		} else {
+			cell_info_control_set_enabled(ctl, nm, FALSE);
+			cell_info_control_set_update_interval(ctl, nm, ms);
+		}
+	}
+
+	CALLBACK_WITH_SUCCESS(cb, data);
+}
+
+static gboolean cellinfo_netmon_register(gpointer user_data)
+{
+	struct cellinfo_netmon_data *nm = user_data;
+
+	nm->register_id = 0;
+	ofono_netmon_register(nm->netmon);
+
+	return G_SOURCE_REMOVE;
+}
+
+static int cellinfo_netmon_probe(struct ofono_netmon *netmon,
+		unsigned int vendor, void *modem)
+{
+	const char *path = ofono_modem_get_path(modem);
+	struct cellinfo_netmon_data *nm =
+		g_new0(struct cellinfo_netmon_data, 1);
+
+	nm->netmon = netmon;
+	nm->ctl = cell_info_control_get(path);
+
+	ofono_netmon_set_data(netmon, nm);
+	nm->register_id = g_idle_add(cellinfo_netmon_register, nm);
+	DBG("%s", path);
+
+	return 0;
+}
+
+static void cellinfo_netmon_remove(struct ofono_netmon *netmon)
+{
+	struct cellinfo_netmon_data *nm = cellinfo_netmon_get_data(netmon);
+
+	DBG("%s", nm->ctl ? nm->ctl->path : "?");
+	ofono_netmon_set_data(netmon, NULL);
+
+	if (nm->update_id) {
+		g_source_remove(nm->update_id);
+	}
+
+	if (nm->register_id) {
+		g_source_remove(nm->register_id);
+	}
+
+	cell_info_control_drop_requests(nm->ctl, nm);
+	cell_info_control_unref(nm->ctl);
+	g_free(nm);
+}
+
+const struct ofono_netmon_driver cellinfo_netmon_driver = {
+	.name                   = "cellinfo",
+	.probe			= cellinfo_netmon_probe,
+	.remove			= cellinfo_netmon_remove,
+	.request_update		= cellinfo_netmon_request_update,
+	.enable_periodic_update = cellinfo_netmon_enable_periodic_update
+};
+
+static int cellinfo_netmon_init(void)
+{
+	return ofono_netmon_driver_register(&cellinfo_netmon_driver);
+}
+
+static void cellinfo_netmon_exit(void)
+{
+	ofono_netmon_driver_unregister(&cellinfo_netmon_driver);
+}
+
+OFONO_PLUGIN_DEFINE(cellinfo_netmon, "CellInfo NetMon Plugin",
+	OFONO_VERSION, OFONO_PLUGIN_PRIORITY_DEFAULT,
+	cellinfo_netmon_init, cellinfo_netmon_exit)
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 8
+ * indent-tabs-mode: t
+ * End:
+ */

--- a/ofono/src/cell-info-control.c
+++ b/ofono/src/cell-info-control.c
@@ -1,0 +1,282 @@
+/*
+ *  oFono - Open Source Telephony - RIL-based devices
+ *
+ *  Copyright (C) 2021 Jolla Ltd.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ */
+
+#include "cell-info-control.h"
+
+#include <ofono/cell-info.h>
+#include <ofono/log.h>
+
+#include <glib.h>
+
+#include <limits.h>
+
+typedef struct cell_info_control_object {
+	CellInfoControl pub;
+	int refcount;
+	char* path;
+	GHashTable *enabled;
+	GHashTable *set_interval;
+} CellInfoControlObject;
+
+static GHashTable *cell_info_control_table = NULL;
+
+static inline CellInfoControlObject *cell_info_control_object_cast
+	(CellInfoControl *ctl)
+{
+	return ctl ? G_STRUCT_MEMBER_P(ctl,
+		- G_STRUCT_OFFSET(CellInfoControlObject, pub)) : NULL;
+}
+
+static int cell_info_control_get_interval(CellInfoControlObject *self)
+{
+	int interval = INT_MAX;
+
+	if (self->set_interval) {
+		GHashTableIter it;
+		gpointer value;
+
+		g_hash_table_iter_init(&it, self->set_interval);
+		while (g_hash_table_iter_next(&it, NULL, &value)) {
+			/* All values are >=0 && < INT_MAX */
+			interval = MIN(interval, GPOINTER_TO_INT(value));
+		}
+	}
+	return interval;
+}
+
+static void cell_info_control_update_all(CellInfoControlObject *self)
+{
+	struct ofono_cell_info *cellinfo = self->pub.info;
+
+	if (cellinfo) {
+		if (self->enabled) {
+			ofono_cell_info_set_update_interval(cellinfo,
+				cell_info_control_get_interval(self));
+			ofono_cell_info_set_enabled(cellinfo, TRUE);
+		} else {
+			ofono_cell_info_set_enabled(cellinfo, FALSE);
+			ofono_cell_info_set_update_interval(cellinfo,
+				cell_info_control_get_interval(self));
+		}
+	}
+}
+
+static void cell_info_control_drop_all_requests_internal
+					(CellInfoControlObject *self)
+{
+	if (self->enabled) {
+		g_hash_table_destroy(self->enabled);
+		self->enabled = NULL;
+	}
+	if (self->set_interval) {
+		g_hash_table_destroy(self->set_interval);
+		self->set_interval = NULL;
+	}
+}
+
+static void cell_info_control_free(CellInfoControlObject *self)
+{
+	/* Destroy the table when the last instance is done */
+	g_hash_table_remove(cell_info_control_table, self->path);
+	if (g_hash_table_size(cell_info_control_table) == 0) {
+		g_hash_table_unref(cell_info_control_table);
+		cell_info_control_table = NULL;
+		DBG("%s gone", self->path);
+	}
+
+	cell_info_control_drop_all_requests_internal(self);
+	ofono_cell_info_unref(self->pub.info);
+	g_free(self->path);
+	g_free(self);
+}
+
+CellInfoControl *cell_info_control_get(const char* path)
+{
+	if (path) {
+		CellInfoControlObject *self = NULL;
+
+		if (cell_info_control_table) {
+			self = g_hash_table_lookup(cell_info_control_table,
+				path);
+		}
+		if (self) {
+			/* Already there */
+			return cell_info_control_ref(&self->pub);
+		} else {
+			/* Create a new one */
+			self = g_new0(CellInfoControlObject, 1);
+			self->pub.path = self->path = g_strdup(path);
+			self->refcount = 1;
+
+			/* Create the table if necessary */
+			if (!cell_info_control_table) {
+				cell_info_control_table =
+					g_hash_table_new(g_str_hash,
+						g_str_equal);
+			}
+			g_hash_table_insert(cell_info_control_table,
+				self->path, self);
+			DBG("%s created", path);
+			return &self->pub;
+		}
+	}
+	return NULL;
+}
+
+CellInfoControl *cell_info_control_ref(CellInfoControl *ctl)
+{
+	CellInfoControlObject *self = cell_info_control_object_cast(ctl);
+
+	if (self) {
+		self->refcount++;
+	}
+	return ctl;
+}
+
+void cell_info_control_unref(CellInfoControl *ctl)
+{
+	CellInfoControlObject *self = cell_info_control_object_cast(ctl);
+
+	if (self && !--self->refcount) {
+		cell_info_control_free(self);
+	}
+}
+
+void cell_info_control_set_cell_info(CellInfoControl *ctl,
+				struct ofono_cell_info *ci)
+{
+	CellInfoControlObject *self = cell_info_control_object_cast(ctl);
+
+	if (self && ctl->info != ci) {
+		ofono_cell_info_unref(ctl->info);
+		ctl->info = ofono_cell_info_ref(ci);
+		cell_info_control_update_all(self);
+	}
+}
+
+void cell_info_control_drop_all_requests(CellInfoControl *ctl)
+{
+	CellInfoControlObject *self = cell_info_control_object_cast(ctl);
+
+	if (self) {
+		cell_info_control_drop_all_requests_internal(self);
+		cell_info_control_update_all(self);
+	}
+}
+
+void cell_info_control_drop_requests(CellInfoControl *ctl, void *tag)
+{
+	CellInfoControlObject *self = cell_info_control_object_cast(ctl);
+
+	if (self && tag) {
+		if (self->enabled &&
+			g_hash_table_remove(self->enabled, tag) &&
+			!g_hash_table_size(self->enabled)) {
+			g_hash_table_unref(self->enabled);
+			self->enabled = NULL;
+			ofono_cell_info_set_enabled(ctl->info, FALSE);
+		}
+		if (self->set_interval &&
+			g_hash_table_remove(self->set_interval, tag)) {
+			int ms;
+
+			if (g_hash_table_size(self->set_interval)) {
+				ms = cell_info_control_get_interval(self);
+			} else {
+				g_hash_table_unref(self->set_interval);
+				self->set_interval = NULL;
+				ms = INT_MAX;
+			}
+			ofono_cell_info_set_update_interval(ctl->info, ms);
+		}
+	}
+}
+
+void cell_info_control_set_enabled(CellInfoControl *ctl,
+	void *tag, ofono_bool_t enabled)
+{
+	CellInfoControlObject *self = cell_info_control_object_cast(ctl);
+
+	if (self && tag) {
+		gboolean was_enabled = (self->enabled != NULL);
+		gboolean is_enabled;
+
+		if (enabled) {
+			if (!self->enabled) {
+				self->enabled = g_hash_table_new(g_direct_hash,
+					g_direct_equal);
+			}
+			g_hash_table_add(self->enabled, tag);
+		} else if (self->enabled) {
+			g_hash_table_remove(self->enabled, tag);
+			if (!g_hash_table_size(self->enabled)) {
+				g_hash_table_unref(self->enabled);
+				self->enabled = NULL;
+			}
+		}
+
+		is_enabled = (self->enabled != NULL);
+		if (is_enabled != was_enabled) {
+			ofono_cell_info_set_enabled(ctl->info, is_enabled);
+		}
+	}
+}
+
+void cell_info_control_set_update_interval(CellInfoControl *ctl,
+	void *tag, int ms)
+{
+	CellInfoControlObject *self = cell_info_control_object_cast(ctl);
+
+	if (self && tag) {
+		int old_interval = cell_info_control_get_interval(self);
+		int new_interval;
+
+		if (ms >= 0 && ms < INT_MAX) {
+			if (!self->set_interval) {
+				self->set_interval =
+					g_hash_table_new(g_direct_hash,
+						g_direct_equal);
+
+			}
+			g_hash_table_insert(self->set_interval, tag,
+				GINT_TO_POINTER(ms));
+		} else if (self->set_interval) {
+			g_hash_table_remove(self->set_interval, tag);
+			if (!g_hash_table_size(self->set_interval)) {
+				g_hash_table_unref(self->set_interval);
+				self->set_interval = NULL;
+			}
+		}
+
+		new_interval = cell_info_control_get_interval(self);
+		if (new_interval != old_interval) {
+			if (new_interval == INT_MAX) {
+				DBG("maximum");
+			} else {
+				DBG("%d ms", new_interval);
+			}
+			ofono_cell_info_set_update_interval(ctl->info,
+				new_interval);
+		}
+	}
+}
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 8
+ * indent-tabs-mode: t
+ * End:
+ */

--- a/ofono/src/cell-info-control.h
+++ b/ofono/src/cell-info-control.h
@@ -1,0 +1,52 @@
+/*
+ *  oFono - Open Source Telephony - RIL-based devices
+ *
+ *  Copyright (C) 2021 Jolla Ltd.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ */
+
+#ifndef CELL_INFO_CONTROL_H
+#define CELL_INFO_CONTROL_H
+
+#include <ofono/types.h>
+
+struct ofono_cell_info;
+
+typedef struct cell_info_control {
+	const char* path;
+	struct ofono_cell_info *info;
+} CellInfoControl;
+
+CellInfoControl *cell_info_control_get(const char* path);
+CellInfoControl *cell_info_control_ref(CellInfoControl *ctl);
+void cell_info_control_unref(CellInfoControl *ctl);
+void cell_info_control_set_cell_info(CellInfoControl *ctl,
+				struct ofono_cell_info *ci);
+void cell_info_control_drop_all_requests(CellInfoControl *ctl);
+void cell_info_control_drop_requests(CellInfoControl *ctl, void *tag);
+
+/* ofono_cell_info gets enabled if there's at least one request to enable it */
+void cell_info_control_set_enabled(CellInfoControl *ctl, void *tag,
+				ofono_bool_t enabled);
+
+/* the actual update interval will be the smallest of the requested */
+void cell_info_control_set_update_interval(CellInfoControl *ctl, void *tag,
+				int ms);
+
+#endif /* CELL_INFO_CONTROL_H */
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 8
+ * indent-tabs-mode: t
+ * End:
+ */

--- a/ofono/src/cell-info-dbus.h
+++ b/ofono/src/cell-info-dbus.h
@@ -16,12 +16,12 @@
 #ifndef CELL_INFO_DBUS_H
 #define CELL_INFO_DBUS_H
 
-struct ofono_modem;
-struct ofono_cell_info;
+#include "cell-info-control.h"
 
 struct cell_info_dbus;
+
 struct cell_info_dbus *cell_info_dbus_new(struct ofono_modem *modem,
-					struct ofono_cell_info *ci);
+					CellInfoControl *ctl);
 void cell_info_dbus_free(struct cell_info_dbus *dbus);
 
 #endif /* CELL_INFO_DBUS_H */

--- a/ofono/unit/coverage
+++ b/ofono/unit/coverage
@@ -17,6 +17,7 @@ TESTS="\
  test-sms-root \
  test-caif \
  test-cell-info \
+ test-cell-info-control \
  test-cell-info-dbus \
  test-conf \
  test-dbus-queue \

--- a/ofono/unit/fake_cell_info.c
+++ b/ofono/unit/fake_cell_info.c
@@ -54,6 +54,7 @@ G_DEFINE_TYPE(FakeCellInfo, fake_cell_info, PARENT_TYPE)
 
 static FakeCellInfo *fake_cell_info_cast(struct ofono_cell_info *info)
 {
+	g_assert(info);
 	return G_CAST(info, FakeCellInfo, info);
 }
 
@@ -158,6 +159,16 @@ struct ofono_cell_info *fake_cell_info_new()
 
 	self->info.proc = &fake_cell_info_proc;
 	return &self->info;
+}
+
+int fake_cell_info_update_interval(struct ofono_cell_info *info)
+{
+	return fake_cell_info_cast(info)->interval;
+}
+
+ofono_bool_t fake_cell_info_is_enabled(struct ofono_cell_info *info)
+{
+	return fake_cell_info_cast(info)->enabled;
 }
 
 void fake_cell_info_add_cell(struct ofono_cell_info *info,

--- a/ofono/unit/fake_cell_info.h
+++ b/ofono/unit/fake_cell_info.h
@@ -19,6 +19,8 @@
 #include <ofono/cell-info.h>
 
 struct ofono_cell_info *fake_cell_info_new(void);
+int fake_cell_info_update_interval(struct ofono_cell_info *info);
+ofono_bool_t fake_cell_info_is_enabled(struct ofono_cell_info *info);
 void fake_cell_info_add_cell(struct ofono_cell_info *info,
 				  const struct ofono_cell* cell);
 ofono_bool_t fake_cell_info_remove_cell(struct ofono_cell_info *info,

--- a/ofono/unit/test-cell-info-control.c
+++ b/ofono/unit/test-cell-info-control.c
@@ -1,0 +1,204 @@
+/*
+ *  oFono - Open Source Telephony
+ *
+ *  Copyright (C) 2021 Jolla Ltd.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ */
+
+#include "ofono.h"
+
+#include "cell-info.h"
+#include "cell-info-control.h"
+
+#include "fake_cell_info.h"
+
+#include <gutil_log.h>
+#include <gutil_macros.h>
+
+#include <limits.h>
+
+#define TEST_(name) "/cell_info_control/" name
+
+/* ==== null ==== */
+
+static void test_null(void)
+{
+	g_assert(!cell_info_control_get(NULL));
+	g_assert(!cell_info_control_ref(NULL));
+	cell_info_control_unref(NULL);
+	cell_info_control_set_cell_info(NULL, NULL);
+	cell_info_control_drop_all_requests(NULL);
+	cell_info_control_drop_requests(NULL, NULL);
+	cell_info_control_set_enabled(NULL, NULL, FALSE);
+	cell_info_control_set_update_interval(NULL, NULL, FALSE);
+}
+
+/* ==== basic ==== */
+
+static void test_basic(void)
+{
+	const char* path = "/test";
+	CellInfoControl *ctl = cell_info_control_get(path);
+	struct ofono_cell_info *info = fake_cell_info_new();
+	void* tag1 = &ctl;
+	void* tag2 = &info;
+
+	/* Second cell_info_control_get returns the same object */
+	g_assert_cmpstr(ctl->path, == ,path);
+	g_assert(cell_info_control_get(path) == ctl);
+	cell_info_control_unref(ctl);
+
+	g_assert(ctl);
+	g_assert(ctl == cell_info_control_ref(ctl));
+	cell_info_control_unref(ctl);
+
+	cell_info_control_set_cell_info(ctl, info);
+
+	/* NULL tag is ignored */
+	cell_info_control_set_enabled(ctl, NULL, TRUE);
+	cell_info_control_set_update_interval(ctl, NULL, 0);
+	g_assert(!fake_cell_info_is_enabled(info));
+	g_assert_cmpint(fake_cell_info_update_interval(info), == ,INT_MAX);
+
+	/* Update all attributes at once when cell_into is set */
+	cell_info_control_set_cell_info(ctl, NULL);
+	cell_info_control_set_enabled(ctl, tag1, TRUE);
+	cell_info_control_set_update_interval(ctl, tag2, 10);
+	cell_info_control_set_cell_info(ctl, info);
+	g_assert(fake_cell_info_is_enabled(info));
+	g_assert_cmpint(fake_cell_info_update_interval(info), == ,10);
+
+	/* And then drop all requests at once */
+	cell_info_control_drop_all_requests(ctl);
+	g_assert(!fake_cell_info_is_enabled(info));
+	g_assert_cmpint(fake_cell_info_update_interval(info), == ,INT_MAX);
+
+	cell_info_control_set_cell_info(ctl, NULL);
+	cell_info_control_unref(ctl);
+	ofono_cell_info_unref(info);
+}
+
+/* ==== enabled ==== */
+
+static void test_enabled(void)
+{
+	CellInfoControl *ctl = cell_info_control_get("/test");
+	struct ofono_cell_info *info = fake_cell_info_new();
+	void* tag1 = &ctl;
+	void* tag2 = &info;
+	void* wrong_tag = &tag1;
+
+	cell_info_control_set_cell_info(ctl, info);
+
+	g_assert(!fake_cell_info_is_enabled(info));
+	cell_info_control_set_enabled(ctl, tag1, TRUE);
+	g_assert(fake_cell_info_is_enabled(info));
+	cell_info_control_set_enabled(ctl, tag2, TRUE);
+	g_assert(fake_cell_info_is_enabled(info));
+	cell_info_control_set_enabled(ctl, tag1, FALSE);
+	g_assert(fake_cell_info_is_enabled(info));
+	cell_info_control_set_enabled(ctl, tag2, FALSE);
+	g_assert(!fake_cell_info_is_enabled(info));
+	cell_info_control_set_enabled(ctl, tag2, FALSE);
+	g_assert(!fake_cell_info_is_enabled(info));
+
+	/* Do it again and then drop the request */
+	cell_info_control_set_enabled(ctl, tag1, TRUE);
+	cell_info_control_set_enabled(ctl, tag2, TRUE);
+	g_assert(fake_cell_info_is_enabled(info));
+	cell_info_control_drop_requests(ctl, tag1);
+	g_assert(fake_cell_info_is_enabled(info)); /* tag2 is still there */
+	cell_info_control_drop_requests(ctl, NULL); /* Ignored */
+	cell_info_control_drop_requests(ctl, tag1); /* Isn't there */
+	cell_info_control_drop_requests(ctl, wrong_tag); /* Wasn't there */
+	g_assert(fake_cell_info_is_enabled(info));
+	cell_info_control_drop_requests(ctl, tag2);
+	g_assert(!fake_cell_info_is_enabled(info));
+
+	/* These have no effect as all requests are already dropped */
+	cell_info_control_drop_requests(ctl, tag1);
+	g_assert(!fake_cell_info_is_enabled(info));
+	cell_info_control_drop_requests(ctl, tag2);
+	g_assert(!fake_cell_info_is_enabled(info));
+
+	cell_info_control_unref(ctl);
+	ofono_cell_info_unref(info);
+}
+
+/* ==== update_interval ==== */
+
+static void test_update_interval(void)
+{
+	CellInfoControl *ctl = cell_info_control_get("/test");
+	struct ofono_cell_info *info = fake_cell_info_new();
+	void* tag1 = &ctl;
+	void* tag2 = &info;
+	void* wrong_tag = &tag1;
+
+	cell_info_control_set_cell_info(ctl, info);
+
+	cell_info_control_set_update_interval(ctl, tag1, 10);
+	g_assert_cmpint(fake_cell_info_update_interval(info), == ,10);
+	cell_info_control_set_update_interval(ctl, tag2, 5);
+	g_assert_cmpint(fake_cell_info_update_interval(info), == ,5);
+	cell_info_control_set_update_interval(ctl, tag2, INT_MAX);
+	g_assert_cmpint(fake_cell_info_update_interval(info), == ,10);
+	cell_info_control_set_update_interval(ctl, tag1, -1);
+	g_assert_cmpint(fake_cell_info_update_interval(info), == ,INT_MAX);
+	cell_info_control_set_update_interval(ctl, tag1, -1);
+	g_assert_cmpint(fake_cell_info_update_interval(info), == ,INT_MAX);
+
+	/* Do it again and then drop the requests one by one */
+	cell_info_control_set_update_interval(ctl, tag1, 5);
+	cell_info_control_set_update_interval(ctl, tag2, 10);
+	g_assert_cmpint(fake_cell_info_update_interval(info), == ,5);
+	cell_info_control_drop_requests(ctl, NULL); /* Ignored */
+	cell_info_control_drop_requests(ctl, wrong_tag); /* Wasn't there */
+	g_assert_cmpint(fake_cell_info_update_interval(info), == ,5);
+	cell_info_control_drop_requests(ctl, tag1);
+	g_assert_cmpint(fake_cell_info_update_interval(info), == ,10);
+	cell_info_control_drop_requests(ctl, tag2);
+	g_assert_cmpint(fake_cell_info_update_interval(info), == ,INT_MAX);
+
+	/* These have no effect as all requests are already dropped */
+	cell_info_control_drop_requests(ctl, tag1);
+	g_assert_cmpint(fake_cell_info_update_interval(info), == ,INT_MAX);
+	cell_info_control_drop_requests(ctl, tag2);
+	g_assert_cmpint(fake_cell_info_update_interval(info), == ,INT_MAX);
+
+	cell_info_control_unref(ctl);
+	ofono_cell_info_unref(info);
+}
+
+int main(int argc, char *argv[])
+{
+	g_test_init(&argc, &argv, NULL);
+
+	gutil_log_timestamp = FALSE;
+	gutil_log_default.level = g_test_verbose() ?
+		GLOG_LEVEL_VERBOSE : GLOG_LEVEL_NONE;
+	__ofono_log_init("test-cell_info_control",
+		g_test_verbose() ? "*" : NULL, FALSE, FALSE);
+
+	g_test_add_func(TEST_("null"), test_null);
+	g_test_add_func(TEST_("basic"), test_basic);
+	g_test_add_func(TEST_("enabled"), test_enabled);
+	g_test_add_func(TEST_("update_interval"), test_update_interval);
+	return g_test_run();
+}
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 8
+ * indent-tabs-mode: t
+ * End:
+ */


### PR DESCRIPTION
Instantiate with `ofono_netmon_create(modem, 0, "cellinfo", modem)`. Requires slot driver to provide `ofono_cell_info` interface. Will be reused by [ofono-ril-plugin](https://github.com/mer-hybris/ofono-ril-plugin) and [ofono-binder-plugin](https://github.com/mer-hybris/ofono-binder-plugin).