### PR TITLE
Add support for sending SMS data messages

### DIFF
--- a/ofono/include/sms.h
+++ b/ofono/include/sms.h
@@ -62,6 +62,7 @@ struct ofono_sms_driver {
 
 enum ofono_sms_data_flag {
 	OFONO_SMS_DATA_FLAG_DELIVERY_REPORT =		0x01,
+	OFONO_SMS_DATA_FLAG_USE_LITTLE_ENDIAN =		0x02,
 };
 
 void ofono_sms_deliver_notify(struct ofono_sms *sms, const unsigned char *pdu,

--- a/ofono/include/sms.h
+++ b/ofono/include/sms.h
@@ -60,6 +60,10 @@ struct ofono_sms_driver {
 				ofono_sms_bearer_set_cb_t, void *data);
 };
 
+enum ofono_sms_data_flag {
+	OFONO_SMS_DATA_FLAG_DELIVERY_REPORT =		0x01,
+};
+
 void ofono_sms_deliver_notify(struct ofono_sms *sms, const unsigned char *pdu,
 				int len, int tpdu_len);
 void ofono_sms_status_notify(struct ofono_sms *sms, const unsigned char *pdu,

--- a/ofono/src/ofono.h
+++ b/ofono/src/ofono.h
@@ -575,6 +575,9 @@ enum sms_class;
 
 typedef void (*sms_send_text_cb_t)(struct ofono_sms *sms,
 		const struct sms_address *addr, const char *text, void *data);
+typedef void (*sms_send_datagram_cb_t)(struct ofono_sms *sms,
+		const struct sms_address *addr, int dstport, int srcport,
+		unsigned char *bytes, unsigned int len, int flags, void *data);
 
 typedef void (*sms_dispatch_recv_text_cb_t)
 	(struct ofono_sms *sms, const struct ofono_uuid *uuid,
@@ -593,6 +596,11 @@ void __ofono_sms_filter_chain_free(struct sms_filter_chain *chain);
 void __ofono_sms_filter_chain_send_text(struct sms_filter_chain *chain,
 		const struct sms_address *addr, const char *text,
 		sms_send_text_cb_t sender, ofono_destroy_func destroy,
+		void *data);
+void __ofono_sms_filter_chain_send_datagram(struct sms_filter_chain *chain,
+		const struct sms_address *addr, int dstport, int srcport,
+		unsigned char *bytes, int len, int flags,
+		sms_send_datagram_cb_t sender, ofono_destroy_func destroy,
 		void *data);
 
 /* Does g_free(buf) when done */

--- a/ofono/src/sms.c
+++ b/ofono/src/sms.c
@@ -1056,6 +1056,7 @@ static void sms_send_data_message_submit(struct ofono_sms *sms,
 	int err;
 	struct ofono_uuid uuid;
 	enum ofono_sms_submit_flag submit_flags;
+	enum sms_datagram_endianess endianess = SMS_DATAGRAM_ENDIANESS_GSM;
 
 	if (bytes == NULL) {
 		__ofono_dbus_pending_reply(&message->pending,
@@ -1063,10 +1064,13 @@ static void sms_send_data_message_submit(struct ofono_sms *sms,
 		return;
 	}
 
+	if (flags & OFONO_SMS_DATA_FLAG_USE_LITTLE_ENDIAN)
+		endianess = SMS_DATAGRAM_ENDIANESS_LITTLE_ENDIAN;
+
 	use_delivery_reports = flags & OFONO_SMS_DATA_FLAG_DELIVERY_REPORT;
-	msg_list = sms_datagram_prepare(to, bytes, len, sms->ref,
+	msg_list = sms_datagram_prepare_with_endianess(to, bytes, len, sms->ref,
 					use_16bit_ref, srcport, dstport, TRUE,
-					use_delivery_reports);
+					use_delivery_reports, endianess);
 
 	if (msg_list == NULL) {
 		__ofono_dbus_pending_reply(&message->pending,

--- a/ofono/src/smsutil.h
+++ b/ofono/src/smsutil.h
@@ -229,6 +229,12 @@ enum cbs_geo_scope {
 	CBS_GEO_SCOPE_CELL_NORMAL
 };
 
+enum sms_datagram_endianess {
+	SMS_DATAGRAM_ENDIANESS_GSM,
+	SMS_DATAGRAM_ENDIANESS_BIG_ENDIAN,
+	SMS_DATAGRAM_ENDIANESS_LITTLE_ENDIAN
+};
+
 struct sms_address {
 	enum sms_number_type number_type;
 	enum sms_numbering_plan numbering_plan;
@@ -573,6 +579,14 @@ GSList *sms_datagram_prepare(const char *to,
 				unsigned short src, unsigned short dst,
 				gboolean use_16bit_port,
 				gboolean use_delivery_reports);
+
+GSList *sms_datagram_prepare_with_endianess(const char *to,
+				const unsigned char *data, unsigned int len,
+				guint16 ref, gboolean use_16bit_ref,
+				unsigned short src, unsigned short dst,
+				gboolean use_16bit_port,
+				gboolean use_delivery_reports,
+				enum sms_datagram_endianess endianess);
 
 gboolean cbs_dcs_decode(guint8 dcs, gboolean *udhi, enum sms_class *cls,
 			enum sms_charset *charset, gboolean *compressed,


### PR DESCRIPTION
This adds a new D-Bus API call "SendDataMessage" to be used for sending a SMS data message. This is required especially by AML but can be utilized for other uses as well.

Also the flags of the "SendDataMessage" call are utilized to set desired endianess. [ETSI spec on AML](https://www.etsi.org/deliver/etsi_ts/103600_103699/103625/01.01.01_60/ts_103625v010101p.pdf), for example, states that either is used for new and other for old implementations.