### PR TITLE
Add ofono_ussd_decode and ofono_ussd_decode_free API

### DIFF
--- a/ofono/include/ussd.h
+++ b/ofono/include/ussd.h
@@ -3,6 +3,7 @@
  *  oFono - Open Source Telephony
  *
  *  Copyright (C) 2008-2011  Intel Corporation. All rights reserved.
+ *  Copyright (C) 2021-2022  Jolla Ltd.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License version 2 as
@@ -68,6 +69,10 @@ void ofono_ussd_remove(struct ofono_ussd *ussd);
 
 void ofono_ussd_set_data(struct ofono_ussd *ussd, void *data);
 void *ofono_ussd_get_data(struct ofono_ussd *ussd);
+
+/* Since mer/1.28+git2 */
+char *ofono_ussd_decode(int dcs, const void *pdu, int len);
+void ofono_ussd_decode_free(char *ussd);
 
 #ifdef __cplusplus
 }

--- a/ofono/src/ussd.c
+++ b/ofono/src/ussd.c
@@ -3,6 +3,7 @@
  *  oFono - Open Source Telephony
  *
  *  Copyright (C) 2008-2011  Intel Corporation. All rights reserved.
+ *  Copyright (C) 2021-2022  Jolla Ltd.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License version 2 as
@@ -969,4 +970,18 @@ void __ofono_ussd_initiate_cancel(struct ofono_ussd *ussd)
 		return;
 
 	ussd->req->cb = NULL;
+}
+
+/* Since mer/1.28+git2 */
+
+char *ofono_ussd_decode(int dcs, const void *pdu, int len)
+{
+	/* Returns NULL-terminated UTF-8 string */
+	return ussd_decode(dcs, len, pdu);
+}
+
+void ofono_ussd_decode_free(char *ussd)
+{
+	/* Deallocates a USSD string returned by ofono_ussd_decode */
+	return g_free(ussd);
 }


### PR DESCRIPTION
Those are required by external plugins to properly support USSD sending. `ofono_ussd_decode_free()` is basically a `g_free()` and its only purpose is to keep ofono API glib-free. External plugins shouldn't make any assumptions about how return values are allocated by the core.