### PR TITLE
Allow filtering for emergency calls

### DIFF
--- a/ofono/src/voicecall.c
+++ b/ofono/src/voicecall.c
@@ -1738,11 +1738,7 @@ static int voicecall_dial(struct ofono_voicecall *vc, const char *number,
 
 	string_to_phone_number(number, &ph);
 
-	/* No filtering for emergency calls */
-	if (is_emergency_number(vc, number))
-		vc->driver->dial(vc, &ph, clir, cb, vc);
-	else
-		dial_filter(vc, &ph, clir, cb, vc);
+	dial_filter(vc, &ph, clir, cb, vc);
 
 	return 0;
 }
@@ -4262,14 +4258,10 @@ static void dial_request(struct ofono_voicecall *vc)
 		struct ofono_modem *modem = __ofono_atom_get_modem(vc->atom);
 
 		__ofono_modem_inc_emergency_mode(modem);
-
-		/* No filtering for emergency calls */
-		vc->driver->dial(vc, &vc->dial_req->ph,
-			OFONO_CLIR_OPTION_DEFAULT, dial_request_cb, vc);
-	} else {
-		dial_filter(vc, &vc->dial_req->ph, OFONO_CLIR_OPTION_DEFAULT,
-				dial_request_cb, vc);
 	}
+
+	dial_filter(vc, &vc->dial_req->ph, OFONO_CLIR_OPTION_DEFAULT,
+					dial_request_cb, vc);
 }
 
 static void dial_req_disconnect_cb(const struct ofono_error *error, void *data)


### PR DESCRIPTION
This removes the exceptions made for emergency calls to disallow
filtering of them via plugins. Thus, this allows the plugins to detect
if an emergency call is made and make an action based on it.