### PR TITLE
[ofono] Require (again) mobile-broadband-provider-info. JB#57703

### DIFF
--- a/rpm/ofono.spec
+++ b/rpm/ofono.spec
@@ -22,7 +22,7 @@ BuildRequires: pkgconfig(rpm)
 Requires:   dbus
 Requires:   systemd
 Requires:   libglibutil >= %{libglibutil_version}
-%{recommend}: mobile-broadband-provider-info
+Requires:   mobile-broadband-provider-info
 %{recommend}: ofono-configs
 Requires(preun): systemd
 Requires(post): systemd


### PR DESCRIPTION
Commit 33744c51 made it recommended only, but the reason for change seemed more of not failing building images without anything providing the ofono-configs. On provider-info there shouldn't be similar problems and there should be a dependency for it.