### PR TITLE
sim: fix use-after-free in open_channel_cb watcher loop

### DIFF
--- a/ofono/src/sim.c
+++ b/ofono/src/sim.c
@@ -3979,9 +3979,9 @@ end:
 		struct ofono_watchlist_item *item = iter->data;
 		ofono_sim_session_event_cb_t notify = item->notify;
 
-		notify(active, session->session_id, item->notify_data);
-
 		iter = g_slist_next(iter);
+
+		notify(active, session->session_id, item->notify_data);
 	}
 }
 


### PR DESCRIPTION
The notify callback (get_session_cb -> sim_fs_end_current) calls __ofono_sim_remove_session_watch, which removes and frees the current GSList node from session->watches->items. iter = g_slist_next(iter) then reads ->next from the freed node, on glibc >=2.40 that field holds a random tcache key, so the next iter->data dereference crashes.

Advance iter before calling notify so the next-pointer is captured before the current node can be freed.